### PR TITLE
feat(api): Add OSPowerSavingState management capabilities

### DIFF
--- a/internal/entity/dto/v1/powerstate.go
+++ b/internal/entity/dto/v1/powerstate.go
@@ -1,5 +1,6 @@
 package dto
 
 type PowerState struct {
-	PowerState int `json:"powerstate" binding:"required" example:"0"`
+	PowerState         int `json:"powerstate" binding:"required" example:"0"`
+	OSPowerSavingState int `json:"osPowerSavingState" binding:"required" example:"0"`
 }

--- a/internal/mocks/devicemanagement_mocks.go
+++ b/internal/mocks/devicemanagement_mocks.go
@@ -21,6 +21,7 @@ import (
 	wsman "github.com/open-amt-cloud-toolkit/console/internal/usecase/devices/wsman"
 	wsman0 "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman"
 	power "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/power"
+	ipspower "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -731,6 +732,21 @@ func (mr *MockDeviceManagementFeatureMockRecorder) GetHardwareInfo(ctx, guid any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareInfo", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetHardwareInfo), ctx, guid)
 }
 
+// GetIPSPowerManagementService mocks base method.
+func (m *MockDeviceManagementFeature) GetIPSPowerManagementService() (ipspower.PowerManagementService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPSPowerManagementService")
+	ret0, _ := ret[0].(ipspower.PowerManagementService)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPSPowerManagementService indicates an expected call of GetIPSPowerManagementService.
+func (mr *MockDeviceManagementFeatureMockRecorder) GetIPSPowerManagementService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPSPowerManagementService", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetIPSPowerManagementService))
+}
+
 // GetNetworkSettings mocks base method.
 func (m *MockDeviceManagementFeature) GetNetworkSettings(c context.Context, guid string) (dto.NetworkSettings, error) {
 	m.ctrl.T.Helper()
@@ -744,6 +760,21 @@ func (m *MockDeviceManagementFeature) GetNetworkSettings(c context.Context, guid
 func (mr *MockDeviceManagementFeatureMockRecorder) GetNetworkSettings(c, guid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkSettings", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetNetworkSettings), c, guid)
+}
+
+// GetOSPowerSavingState mocks base method.
+func (m *MockDeviceManagementFeature) GetOSPowerSavingState() (ipspower.OSPowerSavingState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOSPowerSavingState")
+	ret0, _ := ret[0].(ipspower.OSPowerSavingState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOSPowerSavingState indicates an expected call of GetOSPowerSavingState.
+func (mr *MockDeviceManagementFeatureMockRecorder) GetOSPowerSavingState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSPowerSavingState", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetOSPowerSavingState))
 }
 
 // GetPowerCapabilities mocks base method.
@@ -849,6 +880,21 @@ func (m *MockDeviceManagementFeature) Redirect(ctx context.Context, conn *websoc
 func (mr *MockDeviceManagementFeatureMockRecorder) Redirect(ctx, conn, guid, mode any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Redirect", reflect.TypeOf((*MockDeviceManagementFeature)(nil).Redirect), ctx, conn, guid, mode)
+}
+
+// RequestOSPowerSavingStateChange mocks base method.
+func (m *MockDeviceManagementFeature) RequestOSPowerSavingStateChange(osPowerSavingState ipspower.OSPowerSavingState) (ipspower.PowerActionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestOSPowerSavingStateChange", osPowerSavingState)
+	ret0, _ := ret[0].(ipspower.PowerActionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestOSPowerSavingStateChange indicates an expected call of RequestOSPowerSavingStateChange.
+func (mr *MockDeviceManagementFeatureMockRecorder) RequestOSPowerSavingStateChange(osPowerSavingState interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestOSPowerSavingStateChange", reflect.TypeOf((*MockDeviceManagementFeature)(nil).RequestOSPowerSavingStateChange), osPowerSavingState)
 }
 
 // SendConsentCode mocks base method.

--- a/internal/mocks/wsman_mocks.go
+++ b/internal/mocks/wsman_mocks.go
@@ -32,6 +32,7 @@ import (
 	software "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/software"
 	alarmclock0 "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/alarmclock"
 	optin "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+	ipspower "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -388,6 +389,21 @@ func (mr *MockManagementMockRecorder) GetHardwareInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareInfo", reflect.TypeOf((*MockManagement)(nil).GetHardwareInfo))
 }
 
+// GetIPSPowerManagementService mocks base method.
+func (m *MockManagement) GetIPSPowerManagementService() (ipspower.PowerManagementService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPSPowerManagementService")
+	ret0, _ := ret[0].(ipspower.PowerManagementService)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPSPowerManagementService indicates an expected call of GetIPSPowerManagementService.
+func (mr *MockManagementMockRecorder) GetIPSPowerManagementService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPSPowerManagementService", reflect.TypeOf((*MockManagement)(nil).GetIPSPowerManagementService))
+}
+
 // GetIPSOptInService mocks base method.
 func (m *MockManagement) GetIPSOptInService() (optin.Response, error) {
 	m.ctrl.T.Helper()
@@ -431,6 +447,21 @@ func (m *MockManagement) GetNetworkSettings() (wsman.NetworkResults, error) {
 func (mr *MockManagementMockRecorder) GetNetworkSettings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkSettings", reflect.TypeOf((*MockManagement)(nil).GetNetworkSettings))
+}
+
+// GetOSPowerSavingState mocks base method.
+func (m *MockManagement) GetOSPowerSavingState() (ipspower.OSPowerSavingState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOSPowerSavingState")
+	ret0, _ := ret[0].(ipspower.OSPowerSavingState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOSPowerSavingState indicates an expected call of GetOSPowerSavingState.
+func (mr *MockManagementMockRecorder) GetOSPowerSavingState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSPowerSavingState", reflect.TypeOf((*MockManagement)(nil).GetOSPowerSavingState))
 }
 
 // GetPowerCapabilities mocks base method.
@@ -522,6 +553,21 @@ func (m *MockManagement) RequestAMTRedirectionServiceStateChange(ider, sol bool)
 func (mr *MockManagementMockRecorder) RequestAMTRedirectionServiceStateChange(ider, sol any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestAMTRedirectionServiceStateChange", reflect.TypeOf((*MockManagement)(nil).RequestAMTRedirectionServiceStateChange), ider, sol)
+}
+
+// RequestOSPowerSavingStateChange mocks base method.
+func (m *MockManagement) RequestOSPowerSavingStateChange(osPowerSavingState ipspower.OSPowerSavingState) (ipspower.PowerActionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestOSPowerSavingStateChange", osPowerSavingState)
+	ret0, _ := ret[0].(ipspower.PowerActionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestOSPowerSavingStateChange indicates an expected call of RequestOSPowerSavingStateChange.
+func (mr *MockManagementMockRecorder) RequestOSPowerSavingStateChange(osPowerSavingState interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestOSPowerSavingStateChange", reflect.TypeOf((*MockManagement)(nil).RequestOSPowerSavingStateChange), osPowerSavingState)
 }
 
 // SendConsentCode mocks base method.

--- a/internal/mocks/wsv1_mocks.go
+++ b/internal/mocks/wsv1_mocks.go
@@ -19,6 +19,7 @@ import (
 	dto "github.com/open-amt-cloud-toolkit/console/internal/entity/dto/v1"
 	v2 "github.com/open-amt-cloud-toolkit/console/internal/entity/dto/v2"
 	power "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/power"
+	ipspower "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -422,6 +423,21 @@ func (mr *MockFeatureMockRecorder) GetHardwareInfo(ctx, guid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareInfo", reflect.TypeOf((*MockFeature)(nil).GetHardwareInfo), ctx, guid)
 }
 
+// GetIPSPowerManagementService mocks base method.
+func (m *MockFeature) GetIPSPowerManagementService() (ipspower.PowerManagementService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPSPowerManagementService")
+	ret0, _ := ret[0].(ipspower.PowerManagementService)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPSPowerManagementService indicates an expected call of GetIPSPowerManagementService.
+func (mr *MockFeatureMockRecorder) GetIPSPowerManagementService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPSPowerManagementService", reflect.TypeOf((*MockFeature)(nil).GetIPSPowerManagementService))
+}
+
 // GetNetworkSettings mocks base method.
 func (m *MockFeature) GetNetworkSettings(c context.Context, guid string) (dto.NetworkSettings, error) {
 	m.ctrl.T.Helper()
@@ -435,6 +451,21 @@ func (m *MockFeature) GetNetworkSettings(c context.Context, guid string) (dto.Ne
 func (mr *MockFeatureMockRecorder) GetNetworkSettings(c, guid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkSettings", reflect.TypeOf((*MockFeature)(nil).GetNetworkSettings), c, guid)
+}
+
+// GetOSPowerSavingState mocks base method.
+func (m *MockFeature) GetOSPowerSavingState() (ipspower.OSPowerSavingState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOSPowerSavingState")
+	ret0, _ := ret[0].(ipspower.OSPowerSavingState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOSPowerSavingState indicates an expected call of GetOSPowerSavingState.
+func (mr *MockFeatureMockRecorder) GetOSPowerSavingState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSPowerSavingState", reflect.TypeOf((*MockFeature)(nil).GetOSPowerSavingState))
 }
 
 // GetPowerCapabilities mocks base method.
@@ -540,6 +571,21 @@ func (m *MockFeature) Redirect(ctx context.Context, conn *websocket.Conn, guid, 
 func (mr *MockFeatureMockRecorder) Redirect(ctx, conn, guid, mode any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Redirect", reflect.TypeOf((*MockFeature)(nil).Redirect), ctx, conn, guid, mode)
+}
+
+// RequestOSPowerSavingStateChange mocks base method.
+func (m *MockFeature) RequestOSPowerSavingStateChange(osPowerSavingState ipspower.OSPowerSavingState) (ipspower.PowerActionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestOSPowerSavingStateChange", osPowerSavingState)
+	ret0, _ := ret[0].(ipspower.PowerActionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestOSPowerSavingStateChange indicates an expected call of RequestOSPowerSavingStateChange.
+func (mr *MockFeatureMockRecorder) RequestOSPowerSavingStateChange(osPowerSavingState interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestOSPowerSavingStateChange", reflect.TypeOf((*MockFeature)(nil).RequestOSPowerSavingStateChange), osPowerSavingState)
 }
 
 // SendConsentCode mocks base method.

--- a/internal/usecase/devices/wsman/interfaces.go
+++ b/internal/usecase/devices/wsman/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/cim/software"
 	ipsAlarmClock "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/alarmclock"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+	ipspower "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 
 	"github.com/open-amt-cloud-toolkit/console/internal/entity/dto/v1"
 )
@@ -41,6 +42,9 @@ type Management interface {
 	DeleteAlarmOccurrences(instanceID string) error
 	GetHardwareInfo() (interface{}, error)
 	GetPowerState() ([]service.CIM_AssociatedPowerManagementService, error)
+	GetOSPowerSavingState() (ipspower.OSPowerSavingState, error)
+	GetIPSPowerManagementService() (ipspower.PowerManagementService, error)
+	RequestOSPowerSavingStateChange(osPowerSavingState ipspower.OSPowerSavingState) (ipspower.PowerActionResponse, error)
 	GetPowerCapabilities() (boot.BootCapabilitiesResponse, error)
 	GetGeneralSettings() (interface{}, error)
 	CancelUserConsentRequest() (dto.UserConsentMessage, error)

--- a/internal/usecase/devices/wsman/message.go
+++ b/internal/usecase/devices/wsman/message.go
@@ -52,6 +52,7 @@ import (
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/hostbasedsetup"
 	ipsIEEE8021x "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/ieee8021x"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+	ipspower "github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/ips/power"
 
 	"github.com/open-amt-cloud-toolkit/console/config"
 	"github.com/open-amt-cloud-toolkit/console/internal/entity"
@@ -492,6 +493,33 @@ func (g *ConnectionEntry) GetPowerState() ([]service.CIM_AssociatedPowerManageme
 	}
 
 	return response.Body.PullResponse.AssociatedPowerManagementService, nil
+}
+
+func (g *ConnectionEntry) GetOSPowerSavingState() (ipspower.OSPowerSavingState, error) {
+	response, err := g.GetIPSPowerManagementService()
+	if err != nil {
+		return 0, err
+	}
+
+	return response.OSPowerSavingState, nil
+}
+
+func (g *ConnectionEntry) GetIPSPowerManagementService() (ipspower.PowerManagementService, error) {
+	response, err := g.WsmanMessages.IPS.PowerManagementService.Get()
+	if err != nil {
+		return ipspower.PowerManagementService{}, err
+	}
+
+	return response.Body.GetResponse, nil
+}
+
+func (g *ConnectionEntry) RequestOSPowerSavingStateChange(newOSPowerStavingState ipspower.OSPowerSavingState) (ipspower.PowerActionResponse, error) {
+	response, err := g.WsmanMessages.IPS.PowerManagementService.RequestOSPowerSavingStateChange(newOSPowerStavingState)
+	if err != nil {
+		return ipspower.PowerActionResponse{}, err
+	}
+
+	return response.Body.RequestOSPowerSavingStateChangeResponse, nil
 }
 
 func (g *ConnectionEntry) GetPowerCapabilities() (boot.BootCapabilitiesResponse, error) {


### PR DESCRIPTION
1. It adds osPowerSavingState Change request and get methods.
1. It updates the power action method when the requested power action is 2 (Power On):
    - Check the OSPowerSavingState
    - It requests the OSPowerStateChange to Full Power when the OS is in Power Saving
    - It is incorporated power actions 500 and 501. 500: It modifies the OS Power Saving state from Saving Mode to Full Power Mode. 501: It modifies the OS Power Saving state from Full Mode to Saving Mode
    - It updates the powerState path to add the OSPowerSavingState tag with the corresponding value. The new output returns both PowerState and OSPowerSavingState as follows: { powerstate: '4', OSPowerSavingState: '3' }

1. It incorporates the unitary tests for getPowerState and sendPowerAction
1. It was tested under enterprise mode (console and sample-web-ui) using postman. Screenshots for:
    - Udated getPowerState 
        ![getPowerState](https://github.com/user-attachments/assets/a4c41f97-e446-49e9-813f-e1d55a45a98a)
    - Updated sendPowerAction with action: 2, 500, and 501.
        **Action: 2**
        ![sendPowerAction_action2](https://github.com/user-attachments/assets/a95878e1-c8c8-47b5-bec0-1e4856bd8bc1)
        **Action 500**
        ![sendPowerAction_action500](https://github.com/user-attachments/assets/0aea8684-ef10-46ba-b7d6-3bd0b7b65f12)
        **Action 501**
        ![sendPowerAction_action501_ret2](https://github.com/user-attachments/assets/1e753120-f26f-40a1-b13b-c7f9c764f46f)


