### PR TITLE
fix: upgrade golang base image to 1.24.4 to fix CVE-2025-22874

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Step 1: Modules caching
-FROM golang:1.24-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS modules
+FROM golang:1.24.4-alpine3.20@sha256:e5c2e59960f8636d02f77029c8f0a7a6b882f87fee8d2e4a9ce6c9ff112ed735 AS modules
 COPY go.mod go.sum /modules/
 WORKDIR /modules
 RUN apk add --no-cache git
 RUN go mod download
 
 # Step 2: Builder
-FROM golang:1.24-alpine3.20@sha256:9f98e9893fbc798c710f3432baa1e0ac6127799127c3101d2c263c3a954f0abe AS builder
+FROM golang:1.24.4-alpine3.20@sha256:e5c2e59960f8636d02f77029c8f0a7a6b882f87fee8d2e4a9ce6c9ff112ed735 AS builder
 COPY --from=modules /go/pkg /go/pkg
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Update golang:1.24-alpine3.20 to golang:1.24.4-alpine3.20 to address
high-severity vulnerability in crypto/x509 package where calling Verify
with VerifyOptions.KeyUsages containing ExtKeyUsageAny unintentionally
disabled policy validation.