### PR TITLE
build(docker): default dev service port bindings to loopback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ APP_DISABLE_CIRA=true
 
 # HTTP Server
 # Empty or 0.0.0.0 binds all interfaces.
+# Override Compose bind hosts when needed.
+# VAULT_HOST=127.0.0.1
+# POSTGRES_HOST=127.0.0.1
+# MONGO_HOST=127.0.0.1
+# CONSOLE_HOST=127.0.0.1
 HTTP_HOST=
 HTTP_PORT=8181
 WS_COMPRESSION=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: "mongoadmin"
       MONGO_INITDB_ROOT_PASSWORD: "admin123"
     ports:
-      - "127.0.0.1:27017:27017"
+      - '${MONGO_HOST:-127.0.0.1}:27017:27017'
     healthcheck:
       test:
         - CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     networks:
       - dmtnetwork1
     ports:
-      - '8200:8200'
+      - '${VAULT_HOST:-127.0.0.1}:8200:8200'
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: myroot
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: "admin123"
       POSTGRES_DB: "rpsdb"
     ports:
-      - 5432:5432
+      - '${POSTGRES_HOST:-127.0.0.1}:5432:5432'
   mongo:
     container_name: mongo
     image: mongo:7
@@ -73,7 +73,7 @@ services:
       DB_URL: "${DB_URL:-postgres://postgresadmin:admin123@postgres:5432/rpsdb}"
       AUTH_DISABLED: true
     ports:
-      - 8181:8181
+      - '${CONSOLE_HOST:-127.0.0.1}:8181:8181'
     depends_on:
       postgres:
         condition: service_started


### PR DESCRIPTION
## Summary
This PR fixes the Docker Compose port bindings to localhost by default.

## Problem
Previously, dev services were exposed on all interfaces (`0.0.0.0`) by default:
- Vault: `8200`
- Postgres: `5432`
- Console App: `8181`

This increased host attack surface in local dev environments and enabled unintended network access.

## Validation
Executed:
- `docker compose up -d`
- `docker compose ps`

Observed bindings:
- `127.0.0.1:8181->8181/tcp`
- `127.0.0.1:8200->8200/tcp`
- `127.0.0.1:5432->5432/tcp`

Services are healthy and app routes initialize successfully.

## To run locally
docker compose"
`CONSOLE_HOST=0.0.0.0 POSTGRES_HOST=0.0.0.0 VAULT_HOST=0.0.0.0 docker compose up`

go run directly
`HTTP_HOST=0.0.0.0 go run ./cmd/app/ --config "./config/config.yml"`