### PR TITLE
refactor: reject JWT expiration value at startup if less than 1 sec 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,11 @@ var ConsoleConfig *Config
 // TrayMode indicates whether to run with system tray UI.
 var TrayMode bool
 
+var (
+	ErrJWTExpirationInvalid            = errors.New("config: auth.jwtExpiration must be at least 1 minute (e.g. 24h) — very short expirations render tokens unusable")
+	ErrRedirectionJWTExpirationInvalid = errors.New("config: auth.redirectionJWTExpiration must be at least 1 minute (e.g. 5m) — very short expirations render redirection tokens unusable")
+)
+
 const defaultHost = "localhost"
 
 // DefaultSessionCookieName names the HttpOnly cookie holding the session JWT.
@@ -332,6 +337,21 @@ func SaveAdminPassword(adminPassword string) error {
 	return writeConfig(configPath, fileCfg)
 }
 
+// validate checks that all Config values are sane.
+// It returns an error for any setting that would cause a runtime failure or
+// deny all service to legitimate users (e.g. zero/negative JWT expiration).
+func (c *Config) validate() error {
+	if c.JWTExpiration < time.Minute {
+		return ErrJWTExpirationInvalid
+	}
+
+	if c.RedirectionJWTExpiration < time.Minute {
+		return ErrRedirectionJWTExpirationInvalid
+	}
+
+	return nil
+}
+
 // NewConfig returns app config.
 func NewConfig() (*Config, error) {
 	// set defaults
@@ -354,14 +374,26 @@ func NewConfig() (*Config, error) {
 	// Determine the config path
 	configPath, err := resolveConfigPath(configPathFlag)
 	if err != nil {
+		ConsoleConfig = nil
+
 		return nil, err
 	}
 
 	if err := readOrInitConfig(configPath, ConsoleConfig); err != nil {
+		ConsoleConfig = nil
+
 		return nil, err
 	}
 
 	if err := cleanenv.ReadEnv(ConsoleConfig); err != nil {
+		ConsoleConfig = nil
+
+		return nil, err
+	}
+
+	if err := ConsoleConfig.validate(); err != nil {
+		ConsoleConfig = nil
+
 		return nil, err
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,8 +3,10 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func clearEnv() {
@@ -106,4 +108,89 @@ postgres:
 	assert.Equal(t, "debug", cfg.Level)
 	assert.Equal(t, 10, cfg.PoolMax)
 	assert.Equal(t, "postgres://envuser:envpassword@localhost:5432/envdb", cfg.DB.URL)
+}
+
+func TestNewConfig_InvalidEnvResetsConsoleConfig(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
+	clearEnv()
+
+	// DB_POOL_MAX expects an int; a non-numeric value makes cleanenv fail,
+	// exercising an error path in NewConfig.
+	os.Setenv("DB_POOL_MAX", "not-a-number")
+
+	defer clearEnv()
+
+	cfg, err := NewConfig()
+
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Nil(t, ConsoleConfig)
+}
+
+func TestValidate_ZeroJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.JWTExpiration = 0
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrJWTExpirationInvalid)
+}
+
+func TestValidate_NegativeJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.JWTExpiration = -1 * time.Hour
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrJWTExpirationInvalid)
+}
+
+func TestValidate_SubMinuteJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.JWTExpiration = 30 * time.Second
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrJWTExpirationInvalid)
+}
+
+func TestValidate_ZeroRedirectionJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.RedirectionJWTExpiration = 0
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrRedirectionJWTExpirationInvalid)
+}
+
+func TestValidate_NegativeRedirectionJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.RedirectionJWTExpiration = -5 * time.Minute
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrRedirectionJWTExpirationInvalid)
+}
+
+func TestValidate_SubMinuteRedirectionJWTExpiration(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.RedirectionJWTExpiration = 30 * time.Second
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrRedirectionJWTExpirationInvalid)
+}
+
+func TestValidate_ValidDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+
+	err := cfg.validate()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
**Changes Done:**
- Modified config.go to validate jwtExpiration while console startup
- Reject non-positive values of jwtExpiration

**Description:** 
`config.yml` accepts `jwtExpiration: 0s` which is a syntactically valid zero duration that the YAML parser accepts without error. At runtime, every issued JWT has `exp = time.Now()`, so all tokens expire at the moment of issuance and every subsequent API call is rejected.

**Before fix : Server starts silently with jwtExpiration 0s, login returns an already-expired token:**
```
$ curl -s -X POST http://localhost:8181/api/v1/authorize -H 'Content-Type: application/json' -d '{"username":<USER_NAME>,"password":<PASSWORD>}'
{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."} 

$ curl -s http://localhost:8181/api/v1/devices -H "Authorization: Bearer <token>"
{"error":"invalid access token"} # immediately rejected
```

**After fix : Server would fail to start if jwtExpiration is set to 0s**
```
$ GIN_MODE=debug go run ./cmd/app --config config.yml
Config error: config: auth.jwtExpiration must be positive (e.g. 24h) — zero causes tokens to expire on issuance
exit status 1
```