### PR TITLE
refactor(api): prevent integer overflow in query parameters

### DIFF
--- a/internal/controller/httpapi/v1/auditlog.go
+++ b/internal/controller/httpapi/v1/auditlog.go
@@ -89,8 +89,8 @@ func (r *deviceManagementRoutes) getEventLog(c *gin.Context) {
 	guid := c.Param("guid")
 
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		validationErr := ErrValidationProfile.Wrap("get", "ShouldBindQuery", err)
+	if err := odata.BindAndValidate(c); err != nil {
+		validationErr := ErrValidationProfile.Wrap("get", "BindAndValidate", err)
 		ErrorResponse(c, validationErr)
 
 		return

--- a/internal/controller/httpapi/v1/ciraconfigs.go
+++ b/internal/controller/httpapi/v1/ciraconfigs.go
@@ -32,8 +32,8 @@ func NewCIRAConfigRoutes(handler *gin.RouterGroup, t ciraconfigs.Feature, l logg
 
 func (r *ciraConfigRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		r.l.Error(err, "http - CIRA configs - v1 - getCount")
+	if err := odata.BindAndValidate(c); err != nil {
+		r.l.Error(err, "http - CIRA configs - v1 - get")
 		ErrorResponse(c, err)
 
 		return
@@ -41,7 +41,7 @@ func (r *ciraConfigRoutes) get(c *gin.Context) {
 
 	configs, err := r.cira.Get(c.Request.Context(), odata.Top, odata.Skip, "")
 	if err != nil {
-		r.l.Error(err, "http - CIRA configs - v1 - getCount")
+		r.l.Error(err, "http - CIRA configs - v1 - get")
 		ErrorResponse(c, err)
 
 		return

--- a/internal/controller/httpapi/v1/devices.go
+++ b/internal/controller/httpapi/v1/devices.go
@@ -93,7 +93,7 @@ func (dr *deviceRoutes) LoginRedirection(c *gin.Context) {
 
 func (dr *deviceRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
+	if err := odata.BindAndValidate(c); err != nil {
 		ErrorResponse(c, err)
 
 		return
@@ -169,7 +169,7 @@ func (dr *deviceRoutes) getByColumnOrTags(c *gin.Context, column, value string, 
 
 func (dr *deviceRoutes) getByID(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
+	if err := odata.BindAndValidate(c); err != nil {
 		ErrorResponse(c, err)
 
 		return
@@ -310,7 +310,7 @@ func (dr *deviceRoutes) getTags(c *gin.Context) {
 
 func (dr *deviceRoutes) getDeviceCertificate(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
+	if err := odata.BindAndValidate(c); err != nil {
 		ErrorResponse(c, err)
 
 		return
@@ -372,7 +372,7 @@ func (dr *deviceRoutes) pinDeviceCertificate(c *gin.Context) {
 
 func (dr *deviceRoutes) deleteDeviceCertificate(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
+	if err := odata.BindAndValidate(c); err != nil {
 		ErrorResponse(c, err)
 
 		return

--- a/internal/controller/httpapi/v1/domains.go
+++ b/internal/controller/httpapi/v1/domains.go
@@ -38,8 +38,8 @@ type DomainCountResponse struct {
 
 func (r *domainRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		validationErr := ErrValidationDomains.Wrap("get", "ShouldBindQuery", err)
+	if err := odata.BindAndValidate(c); err != nil {
+		validationErr := ErrValidationDomains.Wrap("get", "BindAndValidate", err)
 		ErrorResponse(c, validationErr)
 
 		return

--- a/internal/controller/httpapi/v1/error.go
+++ b/internal/controller/httpapi/v1/error.go
@@ -32,6 +32,98 @@ type response struct {
 	Message string `json:"message,omitempty" example:"message"`
 }
 
+// handleValidationErrors handles all validation-related errors.
+func handleValidationErrors(c *gin.Context, err error) bool {
+	var (
+		odataValidationErr *ValidationError
+		validatorErr       validator.ValidationErrors
+		notValidErr        dto.NotValidError
+		validationErr      devices.ValidationError
+	)
+
+	switch {
+	case errors.As(err, &odataValidationErr) || errors.Is(err, ErrInvalidInteger) ||
+		errors.Is(err, ErrExceedsMaxRange) || errors.Is(err, ErrNegativeValue) || errors.Is(err, ErrInvalidBoolean):
+		msg := err.Error()
+		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
+
+		return true
+	case errors.As(err, &validatorErr):
+		validatorErrorHandle(c, validatorErr)
+
+		return true
+	case errors.As(err, &notValidErr):
+		notValidErrorHandle(c, notValidErr)
+
+		return true
+	case errors.As(err, &validationErr):
+		msg := validationErr.Console.FriendlyMessage()
+		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
+
+		return true
+	}
+
+	return false
+}
+
+// handleDomainErrors handles domain-specific errors.
+func handleDomainErrors(c *gin.Context, err error) bool {
+	var (
+		certExpErr      domains.CertExpirationError
+		certPasswordErr domains.CertPasswordError
+		notSupportedErr devices.NotSupportedError
+	)
+
+	switch {
+	case errors.As(err, &certExpErr):
+		msg := certExpErr.Console.FriendlyMessage()
+		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
+
+		return true
+	case errors.As(err, &certPasswordErr):
+		msg := certPasswordErr.Console.FriendlyMessage()
+		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
+
+		return true
+	case errors.As(err, &notSupportedErr):
+		msg := notSupportedErr.Console.FriendlyMessage()
+		c.AbortWithStatusJSON(http.StatusNotImplemented, response{Error: msg, Message: msg})
+
+		return true
+	}
+
+	return false
+}
+
+// handleTypedErrors handles remaining typed errors.
+func handleTypedErrors(c *gin.Context, err error) {
+	var (
+		netErr       net.Error
+		cancelledErr dto.CanceledError
+		nfErr        repoerrors.NotFoundError
+		dbErr        repoerrors.DatabaseError
+		notUniqueErr repoerrors.NotUniqueError
+		amtErr       devices.AMTError
+	)
+
+	switch {
+	case errors.As(err, &netErr):
+		netErrorHandle(c, netErr)
+	case errors.As(err, &cancelledErr):
+		cancelledErrorHandle(c, cancelledErr)
+	case errors.As(err, &nfErr):
+		notFoundErrorHandle(c, nfErr)
+	case errors.As(err, &dbErr):
+		dbErrorHandle(c, dbErr)
+	case errors.As(err, &notUniqueErr):
+		notUniqueErrorHandle(c, notUniqueErr)
+	case errors.As(err, &amtErr):
+		amtErrorHandle(c, amtErr)
+	default:
+		c.AbortWithStatusJSON(http.StatusInternalServerError, response{Error: "general error", Message: "general error"})
+	}
+}
+
 // handleSentinelErrors handles well-known sentinel errors that are checked with
 // errors.Is before the typed-error switch. Returns true if the error was handled.
 func handleSentinelErrors(c *gin.Context, err error) bool {
@@ -54,57 +146,19 @@ func handleSentinelErrors(c *gin.Context, err error) bool {
 }
 
 func ErrorResponse(c *gin.Context, err error) {
-	var (
-		validatorErr    validator.ValidationErrors
-		cancelledError  dto.CanceledError
-		nfErr           repoerrors.NotFoundError
-		notValidErr     dto.NotValidError
-		dbErr           repoerrors.DatabaseError
-		notUniqueErr    repoerrors.NotUniqueError
-		amtErr          devices.AMTError
-		notSupportedErr devices.NotSupportedError
-		validationErr   devices.ValidationError
-		certExpErr      domains.CertExpirationError
-		certPasswordErr domains.CertPasswordError
-		netErr          net.Error
-	)
-
 	if handleSentinelErrors(c, err) {
 		return
 	}
 
-	switch {
-	case errors.As(err, &netErr):
-		netErrorHandle(c, netErr)
-	case errors.As(err, &cancelledError):
-		cancelledErrorHandle(c, cancelledError)
-	case errors.As(err, &notValidErr):
-		notValidErrorHandle(c, notValidErr)
-	case errors.As(err, &validatorErr):
-		validatorErrorHandle(c, validatorErr)
-	case errors.As(err, &nfErr):
-		notFoundErrorHandle(c, nfErr)
-	case errors.As(err, &notUniqueErr):
-		notUniqueErrorHandle(c, notUniqueErr)
-	case errors.As(err, &dbErr):
-		dbErrorHandle(c, dbErr)
-	case errors.As(err, &amtErr):
-		amtErrorHandle(c, amtErr)
-	case errors.As(err, &validationErr):
-		msg := validationErr.Console.FriendlyMessage()
-		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
-	case errors.As(err, &notSupportedErr):
-		msg := notSupportedErr.Console.FriendlyMessage()
-		c.AbortWithStatusJSON(http.StatusNotImplemented, response{Error: msg, Message: msg})
-	case errors.As(err, &certExpErr):
-		msg := certExpErr.Console.FriendlyMessage()
-		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
-	case errors.As(err, &certPasswordErr):
-		msg := certPasswordErr.Console.FriendlyMessage()
-		c.AbortWithStatusJSON(http.StatusBadRequest, response{Error: msg, Message: msg})
-	default:
-		c.AbortWithStatusJSON(http.StatusInternalServerError, response{Error: "general error", Message: "general error"})
+	if handleValidationErrors(c, err) {
+		return
 	}
+
+	if handleDomainErrors(c, err) {
+		return
+	}
+
+	handleTypedErrors(c, err)
 }
 
 func netErrorHandle(c *gin.Context, netErr net.Error) {

--- a/internal/controller/httpapi/v1/ieee8021xconfigs.go
+++ b/internal/controller/httpapi/v1/ieee8021xconfigs.go
@@ -44,8 +44,8 @@ func NewIEEE8021xConfigRoutes(handler *gin.RouterGroup, t ieee8021xconfigs.Featu
 
 func (r *ieee8021xConfigRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		validationErr := ErrValidation8021xConfig.Wrap("get", "ShouldBindQuery", err)
+	if err := odata.BindAndValidate(c); err != nil {
+		validationErr := ErrValidation8021xConfig.Wrap("get", "BindAndValidate", err)
 		ErrorResponse(c, validationErr)
 
 		return

--- a/internal/controller/httpapi/v1/odata.go
+++ b/internal/controller/httpapi/v1/odata.go
@@ -1,7 +1,118 @@
 package v1
 
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// MaxPageSize is the maximum allowed value for $top parameter.
+	MaxPageSize = 500
+	// MaxSkipValue is the maximum allowed value for $skip parameter.
+	MaxSkipValue = 100000
+	// DefaultPageSize is the default value for $top when not specified.
+	DefaultPageSize = 25
+	// DecimalBase is the base for decimal integer parsing.
+	DecimalBase = 10
+	// BitSize64 is the bit size for 64-bit integer parsing.
+	BitSize64 = 64
+)
+
+var (
+	// ErrInvalidInteger is returned when a query parameter is not a valid integer.
+	ErrInvalidInteger = errors.New("parameter must be a valid integer")
+	// ErrExceedsMaxRange is returned when a query parameter exceeds the maximum allowed range.
+	ErrExceedsMaxRange = errors.New("parameter value exceeds maximum allowed range")
+	// ErrNegativeValue is returned when a query parameter is negative.
+	ErrNegativeValue = errors.New("parameter must be non-negative")
+	// ErrInvalidBoolean is returned when a boolean query parameter is not a valid boolean.
+	ErrInvalidBoolean = errors.New("parameter must be a boolean value")
+)
+
+// ValidationError represents a query parameter validation error with additional context.
+type ValidationError struct {
+	Max int
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("parameter exceeds maximum allowed value of %d", e.Max)
+}
+
 type OData struct {
 	Top   int  `form:"$top,default=25"`
 	Skip  int  `form:"$skip"`
 	Count bool `form:"$count"`
+}
+
+// BindAndValidate binds query parameters and validates them against overflow and range limits.
+func (o *OData) BindAndValidate(c *gin.Context) error {
+	// Validate $top parameter
+	if topStr := c.Query("$top"); topStr != "" {
+		topVal, err := parseAndValidateInt(topStr, MaxPageSize)
+		if err != nil {
+			return fmt.Errorf("invalid $top parameter: %w", err)
+		}
+
+		o.Top = topVal
+	} else {
+		o.Top = DefaultPageSize
+	}
+
+	// Validate $skip parameter
+	if skipStr := c.Query("$skip"); skipStr != "" {
+		skipVal, err := parseAndValidateInt(skipStr, MaxSkipValue)
+		if err != nil {
+			return fmt.Errorf("invalid $skip parameter: %w", err)
+		}
+
+		o.Skip = skipVal
+	}
+
+	// Validate $count parameter (boolean)
+	if countStr := c.Query("$count"); countStr != "" {
+		countVal, err := strconv.ParseBool(countStr)
+		if err != nil {
+			return fmt.Errorf("invalid $count parameter: %w", ErrInvalidBoolean)
+		}
+
+		o.Count = countVal
+	}
+
+	return nil
+}
+
+// parseAndValidateInt safely parses a string to int and validates range.
+func parseAndValidateInt(value string, maxAllowed int) (int, error) {
+	// First try to parse as int64 to detect overflow beyond int range
+	val64, err := strconv.ParseInt(value, DecimalBase, BitSize64)
+	if err != nil {
+		// Check if it's a range error (number too large)
+		var numErr *strconv.NumError
+		if ok := errors.As(err, &numErr); ok && errors.Is(numErr.Err, strconv.ErrRange) {
+			return 0, ErrExceedsMaxRange
+		}
+
+		return 0, ErrInvalidInteger
+	}
+
+	// Check if value is negative
+	if val64 < 0 {
+		return 0, ErrNegativeValue
+	}
+
+	// Check if value exceeds int max (for 32-bit systems compatibility)
+	if val64 > math.MaxInt32 {
+		return 0, ErrExceedsMaxRange
+	}
+
+	// Check against application-specific maximum
+	if val64 > int64(maxAllowed) {
+		return 0, &ValidationError{Max: maxAllowed}
+	}
+
+	return int(val64), nil
 }

--- a/internal/controller/httpapi/v1/odata_test.go
+++ b/internal/controller/httpapi/v1/odata_test.go
@@ -1,0 +1,257 @@
+package v1
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOData_BindAndValidate(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		queryString string
+		wantErr     bool
+		errContains string
+		wantTop     int
+		wantSkip    int
+		wantCount   bool
+	}{
+		{
+			name:        "valid parameters with default top",
+			queryString: "?$skip=10&$count=true",
+			wantErr:     false,
+			wantTop:     25, // default value
+			wantSkip:    10,
+			wantCount:   true,
+		},
+		{
+			name:        "valid parameters with custom top",
+			queryString: "?$top=100&$skip=50&$count=false",
+			wantErr:     false,
+			wantTop:     100,
+			wantSkip:    50,
+			wantCount:   false,
+		},
+		{
+			name:        "empty query parameters",
+			queryString: "",
+			wantErr:     false,
+			wantTop:     25, // default value
+			wantSkip:    0,
+			wantCount:   false,
+		},
+		{
+			name:        "integer overflow on top parameter",
+			queryString: "?$top=18628037784217768768463850568257440918905312",
+			wantErr:     true,
+			errContains: "exceeds maximum allowed range",
+		},
+		{
+			name:        "integer overflow on skip parameter",
+			queryString: "?$skip=28866823837974031616722743261592341250719431",
+			wantErr:     true,
+			errContains: "exceeds maximum allowed range",
+		},
+		{
+			name:        "integer overflow on count parameter (not integer)",
+			queryString: "?$count=18628037784217768768463850568257440918905312",
+			wantErr:     true,
+			errContains: "must be a boolean value",
+		},
+		{
+			name:        "negative top parameter",
+			queryString: "?$top=-10",
+			wantErr:     true,
+			errContains: "must be non-negative",
+		},
+		{
+			name:        "negative skip parameter",
+			queryString: "?$skip=-5",
+			wantErr:     true,
+			errContains: "must be non-negative",
+		},
+		{
+			name:        "top exceeds maximum allowed",
+			queryString: fmt.Sprintf("?$top=%d", MaxPageSize+1),
+			wantErr:     true,
+			errContains: "exceeds maximum allowed value",
+		},
+		{
+			name:        "skip exceeds maximum allowed",
+			queryString: fmt.Sprintf("?$skip=%d", MaxSkipValue+1),
+			wantErr:     true,
+			errContains: "exceeds maximum allowed value",
+		},
+		{
+			name:        "top exceeds int32 max",
+			queryString: fmt.Sprintf("?$top=%d", int64(math.MaxInt32)+1),
+			wantErr:     true,
+			errContains: "exceeds maximum allowed range",
+		},
+		{
+			name:        "skip exceeds int32 max",
+			queryString: fmt.Sprintf("?$skip=%d", int64(math.MaxInt32)+1),
+			wantErr:     true,
+			errContains: "exceeds maximum allowed range",
+		},
+		{
+			name:        "non-numeric top parameter",
+			queryString: "?$top=abc",
+			wantErr:     true,
+			errContains: "must be a valid integer",
+		},
+		{
+			name:        "non-numeric skip parameter",
+			queryString: "?$skip=xyz",
+			wantErr:     true,
+			errContains: "must be a valid integer",
+		},
+		{
+			name:        "maximum allowed top value",
+			queryString: fmt.Sprintf("?$top=%d", MaxPageSize),
+			wantErr:     false,
+			wantTop:     MaxPageSize,
+			wantSkip:    0,
+			wantCount:   false,
+		},
+		{
+			name:        "maximum allowed skip value",
+			queryString: fmt.Sprintf("?$skip=%d", MaxSkipValue),
+			wantErr:     false,
+			wantTop:     25,
+			wantSkip:    MaxSkipValue,
+			wantCount:   false,
+		},
+		{
+			name:        "boundary test - zero values",
+			queryString: "?$top=0&$skip=0",
+			wantErr:     false,
+			wantTop:     0,
+			wantSkip:    0,
+			wantCount:   false,
+		},
+		{
+			name:        "float top parameter (invalid)",
+			queryString: "?$top=10.5",
+			wantErr:     true,
+			errContains: "must be a valid integer",
+		},
+		{
+			name:        "scientific notation (large number)",
+			queryString: "?$top=1e20",
+			wantErr:     true,
+			errContains: "must be a valid integer",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create test request and context
+			req := httptest.NewRequest(http.MethodGet, "/test"+tt.queryString, http.NoBody)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			// Test the BindAndValidate method
+			var odata OData
+
+			err := odata.BindAndValidate(c)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantTop, odata.Top)
+				assert.Equal(t, tt.wantSkip, odata.Skip)
+				assert.Equal(t, tt.wantCount, odata.Count)
+			}
+		})
+	}
+}
+
+func TestParseAndValidateInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		value      string
+		maxAllowed int
+		want       int
+		wantErr    bool
+	}{
+		{
+			name:       "valid positive integer",
+			value:      "100",
+			maxAllowed: 1000,
+			want:       100,
+			wantErr:    false,
+		},
+		{
+			name:       "zero value",
+			value:      "0",
+			maxAllowed: 1000,
+			want:       0,
+			wantErr:    false,
+		},
+		{
+			name:       "negative value",
+			value:      "-10",
+			maxAllowed: 1000,
+			wantErr:    true,
+		},
+		{
+			name:       "exceeds max allowed",
+			value:      "2000",
+			maxAllowed: 1000,
+			wantErr:    true,
+		},
+		{
+			name:       "exceeds int32 max",
+			value:      fmt.Sprintf("%d", int64(math.MaxInt32)+1),
+			maxAllowed: math.MaxInt32,
+			wantErr:    true,
+		},
+		{
+			name:       "overflow - number too large",
+			value:      "999999999999999999999999999999",
+			maxAllowed: 1000,
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric string",
+			value:      "abc",
+			maxAllowed: 1000,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseAndValidateInt(tt.value, tt.maxAllowed)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/controller/httpapi/v1/profiles.go
+++ b/internal/controller/httpapi/v1/profiles.go
@@ -46,8 +46,8 @@ func NewProfileRoutes(handler *gin.RouterGroup, t profiles.Feature, l logger.Int
 
 func (r *profileRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		validationErr := ErrValidationProfile.Wrap("get", "ShouldBindQuery", err)
+	if err := odata.BindAndValidate(c); err != nil {
+		validationErr := ErrValidationProfile.Wrap("get", "BindAndValidate", err)
 		ErrorResponse(c, validationErr)
 
 		return

--- a/internal/controller/httpapi/v1/wificonfigs.go
+++ b/internal/controller/httpapi/v1/wificonfigs.go
@@ -44,8 +44,8 @@ func NewWirelessConfigRoutes(handler *gin.RouterGroup, t wificonfigs.Feature, l 
 
 func (r *WirelessConfigRoutes) get(c *gin.Context) {
 	var odata OData
-	if err := c.ShouldBindQuery(&odata); err != nil {
-		validationErr := ErrValidationWifiConfig.Wrap("get", "ShouldBindQuery", err)
+	if err := odata.BindAndValidate(c); err != nil {
+		validationErr := ErrValidationWifiConfig.Wrap("get", "BindAndValidate", err)
 		ErrorResponse(c, validationErr)
 
 		return


### PR DESCRIPTION
* Add validation to prevent integer overflow in query parameters (top, skip, count).
* Returns 400 instead of 500 on invalid input.

# Test

Get token

```bash
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize -H "Content-Type: application/json" -d '{"username":"<username>","password":"<password>"}' | jq -r '.token')
```

Test 1: Integer overflow on $top (should return 400, NOT 500)

```bash
curl -sk -i "https://localhost:8181/api/v1/devices?\$top=99999999999999999999999999999" \
  -H "Authorization: Bearer $TOKEN"
```

Output:

```bash
HTTP/2 400 
content-type: application/json; charset=utf-8
content-length: 163
date: Fri, 07 Aug 2026 04:55:25 GMT

{"error":"invalid $top parameter: parameter value exceeds maximum allowed range","message":"invalid $top parameter: parameter value exceeds maximum allowed range"}
```

Test 2: Integer overflow on $skip (should return 400, NOT 500)

```bash
curl -sk -i "https://localhost:8181/api/v1/devices?\$skip=28866823837974031616722743261592341250719431" \
  -H "Authorization: Bearer $TOKEN"
```

Output:

```bash
HTTP/2 400 
content-type: application/json; charset=utf-8
content-length: 165
date: Fri, 07 Aug 2026 04:56:10 GMT

{"error":"invalid $skip parameter: parameter value exceeds maximum allowed range","message":"invalid $skip parameter: parameter value exceeds maximum allowed range"}
```

Test 3: Negative value (should return 400)

```bash
curl -sk -i "https://localhost:8181/api/v1/devices?\$top=-10" \
  -H "Authorization: Bearer $TOKEN"
```

Output:

```bash
HTTP/2 400 
content-type: application/json; charset=utf-8
content-length: 133
date: Fri, 07 Aug 2026 04:56:42 GMT

{"error":"invalid $top parameter: parameter must be non-negative","message":"invalid $top parameter: parameter must be non-negative"}
```

Test 4: Exceeds max allowed (should return 400)

```bash
curl -sk -i "https://localhost:8181/api/v1/devices?\$top=50000" \
  -H "Authorization: Bearer $TOKEN"
```

Output:

```bash
HTTP/2 400 
content-type: application/json; charset=utf-8
content-length: 169
date: Fri, 07 Aug 2026 04:57:10 GMT

{"error":"invalid $top parameter: parameter exceeds maximum allowed value of 500","message":"invalid $top parameter: parameter exceeds maximum allowed value of 500"}
```


Test 5: Valid request (should return 200 with data)

```bash
curl -sk -i "https://localhost:8181/api/v1/devices?\$top=10&\$skip=0&\$count=true" \
  -H "Authorization: Bearer $TOKEN"
```

Output:

```bash
HTTP/2 200 
content-type: application/json; charset=utf-8
content-length: 1733
date: Fri, 07 Aug 2026 04:57:37 GMT

{"totalCount":2,"data":[{"connectionStatus":false,"mpsInstance":"","hostname":"<host-ip-addr>","guid":"<guid>","mpsusername":"","tags":null,"tenantId":"","friendlyName":"MININT-67OALSL","dnsSuffix":"","deviceInfo":{"fwVersion":"20.0.5","fwBuild":"1628","fwSku":"16392","discovered":false,"currentMode":"not activated","features":"AMT Pro Corporate","ipAddress":"<ip-addr>","lastSynced":"2026-08-03T07:43:34.3493246Z","lmsInstalled":true,"lmsVersion":"2542.0.5.0","amtEnabledInBIOS":true,"meInterfaceVersion":"2542.0.52.0","dhcpEnabled":true,"osName":"windows","osVersion":"10.0.26100.8875 Build 26100.8875","osDistro":"Microsoft Windows 11 Enterprise 24H2","cpuModel":"Intel(R) Core(TM) Ultra 5 238V","osIpAddress":"<ip-addr>","ethernetAdapterCount":1,"monitorConnected":true},"username":"<username>","password":"","mpspassword":"","mebxpassword":"","useTLS":true,"allowSelfSigned":true,"certHash":""},{"connectionStatus":false,"mpsInstance":"","hostname":"<host-ip-addr>","guid":"<guid>","mpsusername":"","tags":null,"tenantId":"","friendlyName":"","dnsSuffix":"","deviceInfo":{"fwVersion":"","fwBuild":"","fwSku":"","discovered":true,"firstDiscovered":"2026-07-27T05:37:35.973182717Z","currentMode":"","features":"","ipAddress":"0.0.0.0","lastSynced":"2026-07-27T05:37:35.973182717Z","lmsInstalled":false,"meInterfaceVersion":"6.8.0-111-generic","osName":"linux","osVersion":"6.8.0-111-generic","osDistro":"Ubuntu 22.04.5 LTS","cpuModel":"Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz","osIpAddress":"<ip-addr>","ethernetAdapterCount":1,"monitorConnected":true},"username":"","password":"","mpspassword":"","mebxpassword":"","useTLS":false,"allowSelfSigned":false,"certHash":""}]}
```