### PR TITLE
refactor: Implement throttling for POST /api/v1/authorize

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ HTTP_PORT=8181
 WS_COMPRESSION=false
 HTTP_ALLOWED_ORIGINS=*
 HTTP_ALLOWED_HEADERS=*
+# Comma-separated reverse-proxy CIDR ranges / IPs allowed to set X-Forwarded-For
+# (e.g. HTTP_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.1).
+# Leave empty (default) for direct-access deployments; set for cloud/LB setups.
+HTTP_TRUSTED_PROXIES=
 
 # TLS
 # Enable TLS in release if the app terminates TLS itself. If behind an API gateway or LB that provides TLS, set to false.

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,12 @@ type (
 		AllowedOrigins []string `env-required:"true" yaml:"allowed_origins" env:"HTTP_ALLOWED_ORIGINS"`
 		AllowedHeaders []string `env-required:"true" yaml:"allowed_headers" env:"HTTP_ALLOWED_HEADERS"`
 		WSCompression  bool     `yaml:"ws_compression" env:"WS_COMPRESSION"`
+		// TrustedProxies is the list of CIDR ranges or IP addresses of reverse proxies
+		// that are allowed to set X-Forwarded-For. Leave empty (the default) when the
+		// server is accessed directly — this forces c.ClientIP() to use RemoteAddr,
+		// which cannot be spoofed at the HTTP layer. Cloud / load-balanced deployments
+		// must set this to the proxy CIDR(s) so per-IP rate limiting works correctly.
+		TrustedProxies []string `yaml:"trusted_proxies" env:"HTTP_TRUSTED_PROXIES"`
 		TLS            TLS      `yaml:"tls"`
 	}
 
@@ -160,6 +166,10 @@ func defaultConfig() *Config {
 			AllowedOrigins: []string{"*"},
 			AllowedHeaders: []string{"*"},
 			WSCompression:  true,
+			// TrustedProxies is nil by default: no proxy is trusted, so c.ClientIP()
+			// uses RemoteAddr (unspoofable) for the per-IP login rate limiter.
+			// Set HTTP_TRUSTED_PROXIES to the proxy CIDR(s) when running behind an LB.
+			TrustedProxies: nil,
 			TLS: TLS{
 				Enabled:  true,
 				CertFile: "",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,6 +74,19 @@ func setupHTTPHandler(cfg *config.Config, log logger.Interface, usecases *usecas
 
 	handler := gin.New()
 
+	// Restrict which proxies may set X-Forwarded-For so the per-IP login
+	// rate limiter cannot be bypassed by rotating a spoofed header value.
+	// nil disables proxy trust entirely and forces use of RemoteAddr.
+	if len(cfg.TrustedProxies) == 0 {
+		log.Info("HTTP_TRUSTED_PROXIES not set: using RemoteAddr for client IP (correct for direct-access deployments; set this when running behind a load balancer)")
+	}
+
+	if err := handler.SetTrustedProxies(cfg.TrustedProxies); err != nil {
+		log.Warn("invalid HTTP_TRUSTED_PROXIES value, falling back to no trusted proxies: " + err.Error())
+
+		_ = handler.SetTrustedProxies(nil)
+	}
+
 	defaultConfig := cors.DefaultConfig()
 	defaultConfig.AllowOrigins = cfg.AllowedOrigins
 	defaultConfig.AllowHeaders = cfg.AllowedHeaders

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -7,32 +7,56 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/time/rate"
 
 	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 	"github.com/device-management-toolkit/console/pkg/consoleerrors"
 )
 
+const (
+	loginRateBurst         = 5                // loginRateBurst is the maximum burst of login attempts allowed before throttling.
+	loginRateWindow        = 12 * time.Second // loginRateWindow is the token-refill interval: one token per window → 5 per minute.
+	limiterTTL             = 15 * time.Minute // limiterTTL is how long an idle per-IP entry is kept before the cleanup goroutine removes it.
+	limiterCleanupInterval = 5 * time.Minute  // limiterCleanupInterval is how often the cleanup goroutine sweeps stale entries.
+)
+
+// loginRatePerIP is the sustained token-refill rate: one token every loginRateWindow → 5 per minute.
+var loginRatePerIP = rate.Every(loginRateWindow) //nolint:gochecknoglobals // rate.Limit is a float64; cannot be const
+
 var (
 	ErrLogin                   = consoleerrors.CreateConsoleError("LoginHandler")
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
 )
 
+// ipEntry pairs a rate limiter with the last time it was accessed, enabling
+// stale-entry cleanup without tracking a separate timestamp map.
+type ipEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
 type LoginRoute struct {
 	Config   *config.Config
 	Verifier *oidc.IDTokenVerifier
+	mu       sync.Mutex
+	limiters map[string]*ipEntry
 }
 
-// NewVersionRoute creates a new version route
+// NewLoginRoute creates a new login route with per-IP rate limiting enabled.
 func NewLoginRoute(configData *config.Config) *LoginRoute {
 	lr := &LoginRoute{
-		Config: configData,
+		Config:   configData,
+		limiters: make(map[string]*ipEntry),
 	}
+
+	go lr.cleanupLoop()
 
 	if config.ConsoleConfig.ClientID != "" {
 		ctx := context.Background()
@@ -61,8 +85,58 @@ func NewLoginRoute(configData *config.Config) *LoginRoute {
 	return lr
 }
 
-// Login checks configured credentials and returns a JWT token for basic auth
-func (lr LoginRoute) Login(c *gin.Context) {
+// getLimiter returns (creating if necessary) the rate limiter for the given IP.
+func (lr *LoginRoute) getLimiter(ip string) *rate.Limiter {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	// Lazy-initialize so direct struct construction in tests still works.
+	if lr.limiters == nil {
+		lr.limiters = make(map[string]*ipEntry)
+	}
+
+	entry, ok := lr.limiters[ip]
+	if !ok {
+		entry = &ipEntry{limiter: rate.NewLimiter(loginRatePerIP, loginRateBurst)}
+		lr.limiters[ip] = entry
+	}
+
+	entry.lastSeen = time.Now()
+
+	return entry.limiter
+}
+
+// cleanupLoop removes stale per-IP limiters on a fixed interval.
+// It runs as a background goroutine for the lifetime of the server.
+func (lr *LoginRoute) cleanupLoop() {
+	ticker := time.NewTicker(limiterCleanupInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		lr.mu.Lock()
+
+		for ip, entry := range lr.limiters {
+			if time.Since(entry.lastSeen) > limiterTTL {
+				delete(lr.limiters, ip)
+			}
+		}
+
+		lr.mu.Unlock()
+	}
+}
+
+// Login checks configured credentials and returns a JWT token for basic auth.
+func (lr *LoginRoute) Login(c *gin.Context) {
+	if !lr.getLimiter(c.ClientIP()).Allow() {
+		c.Header("Retry-After", "60")
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			errorKey:   "too many requests",
+			messageKey: "Too many login attempts. Please try again later.",
+		})
+
+		return
+	}
+
 	var creds dto.Credentials
 
 	if err := c.ShouldBindJSON(&creds); err != nil {
@@ -74,7 +148,7 @@ func (lr LoginRoute) Login(c *gin.Context) {
 	lr.handleBasicAuth(creds, c)
 }
 
-func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
+func (lr *LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 	if creds.Username != lr.Config.AdminUsername || creds.Password != lr.Config.AdminPassword {
 		c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid credentials", messageKey: "Incorrect Username and/or Password!"})
 
@@ -101,7 +175,7 @@ func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 }
 
 // JWT Middleware
-func (lr LoginRoute) JWTAuthMiddleware() gin.HandlerFunc {
+func (lr *LoginRoute) JWTAuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenString := c.GetHeader("Authorization")
 		tokenString = strings.Replace(tokenString, "Bearer ", "", 1)

--- a/internal/controller/httpapi/v1/login_test.go
+++ b/internal/controller/httpapi/v1/login_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,6 +34,85 @@ func TestLogin_InvalidCredentialsReturnsMessage(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 	require.Equal(t, "invalid credentials", got["error"])
 	require.Equal(t, "Incorrect Username and/or Password!", got["message"])
+}
+
+func TestLogin_RateLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	engine := gin.New()
+	route := LoginRoute{Config: &config.Config{Auth: config.Auth{AdminUsername: "admin", AdminPassword: "secret"}}}
+	engine.POST("/api/v1/authorize", route.Login)
+
+	makeRequest := func() *httptest.ResponseRecorder {
+		req, err := http.NewRequest(http.MethodPost, "/api/v1/authorize", bytes.NewBufferString(`{"username":"admin","password":"wrong"}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		// All requests from the same IP so they share one limiter bucket.
+		req.RemoteAddr = "192.0.2.1:1234"
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		return w
+	}
+
+	// Exhaust the burst allowance (loginRateBurst == 5).
+	for range loginRateBurst {
+		w := makeRequest()
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+
+	// The next request must be throttled.
+	w := makeRequest()
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+	require.Equal(t, "60", w.Header().Get("Retry-After"))
+
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, "too many requests", got["error"])
+}
+
+// TestLogin_SpoofedXForwardedForCannotBypassRateLimit verifies that when no
+// proxies are trusted (the default), rotating the X-Forwarded-For header does
+// not create a fresh limiter bucket per request. Gin's default engine trusts
+// all proxies, so we explicitly clear the trusted proxy list to mirror the
+// production wiring in app.go (SetTrustedProxies(nil)).
+func TestLogin_SpoofedXForwardedForCannotBypassRateLimit(t *testing.T) {
+	t.Parallel()
+
+	engine := gin.New()
+	// Mirror production: trust no proxies, so c.ClientIP() uses RemoteAddr and
+	// ignores any client-supplied X-Forwarded-For header.
+	require.NoError(t, engine.SetTrustedProxies(nil))
+
+	route := LoginRoute{Config: &config.Config{Auth: config.Auth{AdminUsername: "admin", AdminPassword: "secret"}}}
+	engine.POST("/api/v1/authorize", route.Login)
+
+	makeRequest := func(spoofedIP string) *httptest.ResponseRecorder {
+		req, err := http.NewRequest(http.MethodPost, "/api/v1/authorize", bytes.NewBufferString(`{"username":"admin","password":"wrong"}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		// Same real connection IP, but a different forged X-Forwarded-For each time.
+		req.RemoteAddr = "192.0.2.50:1234"
+		req.Header.Set("X-Forwarded-For", spoofedIP)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		return w
+	}
+
+	// Exhaust the burst using a different spoofed IP on every request. If the
+	// header were trusted, each would get its own bucket and never throttle.
+	for i := range loginRateBurst {
+		w := makeRequest(fmt.Sprintf("10.10.10.%d", i))
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+
+	// Despite a fresh spoofed X-Forwarded-For, the shared RemoteAddr bucket is
+	// now empty, so this request must be throttled.
+	w := makeRequest("10.10.10.99")
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
 }
 
 // oidcDiscoveryServer spins up a TLS test server that serves the minimum

--- a/internal/controller/openapi/devices.go
+++ b/internal/controller/openapi/devices.go
@@ -23,6 +23,7 @@ func (f *FuegoAdapter) registerDeviceAuthRoutes() {
 		fuego.OptionSummary("Authorize"),
 		fuego.OptionDescription("Authenticate and return an access token"),
 		fuego.OptionAddResponse(http.StatusUnauthorized, "Unauthorized: invalid credentials", fuego.Response{Type: ErrorResponse{}}),
+		fuego.OptionAddResponse(http.StatusTooManyRequests, "Too many login attempts: rate limit exceeded", fuego.Response{Type: ErrorResponse{}}),
 	)
 
 	fuego.Get(f.server, "/api/v1/authorize/redirection/{id}", f.loginRedirection,


### PR DESCRIPTION
- Implemented IP token-bucket limiter (burst 5, refill 1/12s) to the Login handler.
- IP token-bucket limiter (burst 5, refill 1/12s) to the Login handler.
- Update the Fuego/OpenAPI declaration with the 429 response