### PR TITLE
refactor(api): issue session JWT as an HttpOnly cookie

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ HTTP_PORT=8181
 WS_COMPRESSION=false
 HTTP_ALLOWED_ORIGINS=*
 HTTP_ALLOWED_HEADERS=*
+# Lets a cross-origin browser send the session cookie. Ignored while
+# HTTP_ALLOWED_ORIGINS is "*" (CORS forbids credentials with a wildcard).
+# Same-origin deployments do not need this.
+HTTP_ALLOW_CREDENTIALS=false
 
 # TLS
 # Enable TLS in release if the app terminates TLS itself. If behind an API gateway or LB that provides TLS, set to false.
@@ -46,8 +50,19 @@ AUTH_ADMIN_PASSWORD=
 AUTH_JWT_KEY=your_secret_jwt_key
 AUTH_JWT_EXPIRATION=24h
 AUTH_REDIRECTION_JWT_EXPIRATION=5m
+# Ignored when AUTH_CLIENT_ID is set (OIDC).
+AUTH_COOKIE_ENABLED=true
+AUTH_COOKIE_NAME=console_session
+# Set false only when Console is served over plain HTTP on a non-localhost
+# address; browsers drop Secure cookies there.
+AUTH_COOKIE_SECURE=true
+# strict | lax | none. "none" needs HTTP_ALLOW_CREDENTIALS and explicit origins.
+# SameSite is currently the only CSRF defence for cookie auth, so "none" leaves
+# state-changing requests unprotected. Keep strict unless you have to loosen it.
+AUTH_COOKIE_SAME_SITE=strict
 AUTH_CLIENT_ID=
-AUTH_ISSUER=GIN_MODE=release
+AUTH_ISSUER=
+GIN_MODE=release
 # DB_URL=postgres://postgresadmin:admin123@localhost:5432/rpsdb
 # OAUTH CONFIGURATION
 AUTH_CLIENT_ID=

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,9 @@ var TrayMode bool
 
 const defaultHost = "localhost"
 
+// DefaultSessionCookieName names the HttpOnly cookie holding the session JWT.
+const DefaultSessionCookieName = "console_session"
+
 type (
 	// Config -.
 	Config struct {
@@ -45,12 +48,13 @@ type (
 
 	// HTTP -.
 	HTTP struct {
-		Host           string   `yaml:"host" env:"HTTP_HOST"`
-		Port           string   `env-required:"true" yaml:"port" env:"HTTP_PORT"`
-		AllowedOrigins []string `env-required:"true" yaml:"allowed_origins" env:"HTTP_ALLOWED_ORIGINS"`
-		AllowedHeaders []string `env-required:"true" yaml:"allowed_headers" env:"HTTP_ALLOWED_HEADERS"`
-		WSCompression  bool     `yaml:"ws_compression" env:"WS_COMPRESSION"`
-		TLS            TLS      `yaml:"tls"`
+		Host             string   `yaml:"host" env:"HTTP_HOST"`
+		Port             string   `env-required:"true" yaml:"port" env:"HTTP_PORT"`
+		AllowedOrigins   []string `env-required:"true" yaml:"allowed_origins" env:"HTTP_ALLOWED_ORIGINS"`
+		AllowedHeaders   []string `env-required:"true" yaml:"allowed_headers" env:"HTTP_ALLOWED_HEADERS"`
+		AllowCredentials bool     `yaml:"allow_credentials" env:"HTTP_ALLOW_CREDENTIALS"`
+		WSCompression    bool     `yaml:"ws_compression" env:"WS_COMPRESSION"`
+		TLS              TLS      `yaml:"tls"`
 	}
 
 	// TLS -.
@@ -90,6 +94,11 @@ type (
 	}
 
 	// Auth -.
+	//
+	// The Cookie* fields govern the HttpOnly session cookie the browser uses in
+	// place of Web Storage. Additive only: /authorize still returns the token in
+	// the body and the Authorization header still wins, so REST clients are
+	// unaffected.
 	Auth struct {
 		Disabled                 bool          `yaml:"disabled" env:"AUTH_DISABLED"`
 		AdminUsername            string        `yaml:"adminUsername" env:"AUTH_ADMIN_USERNAME"`
@@ -100,6 +109,10 @@ type (
 		ClientID                 string        `yaml:"clientId" env:"AUTH_CLIENT_ID"`
 		Issuer                   string        `yaml:"issuer" env:"AUTH_ISSUER"`
 		TLSSkipVerify            bool          `yaml:"tlsSkipVerify" env:"AUTH_TLS_SKIP_VERIFY"`
+		CookieEnabled            bool          `yaml:"cookieEnabled" env:"AUTH_COOKIE_ENABLED"`
+		CookieName               string        `yaml:"cookieName" env:"AUTH_COOKIE_NAME"`
+		CookieSecure             bool          `yaml:"cookieSecure" env:"AUTH_COOKIE_SECURE"`
+		CookieSameSite           string        `yaml:"cookieSameSite" env:"AUTH_COOKIE_SAME_SITE"`
 		UI                       UIAuthConfig  `yaml:"ui"`
 	}
 
@@ -119,6 +132,12 @@ type (
 		ExternalURL string `yaml:"externalUrl" env:"UI_EXTERNAL_URL"`
 	}
 )
+
+// CookieAuthEnabled reports whether the HttpOnly session cookie is in use. Off
+// under OIDC, where the IdP owns the token. Read by the middleware and the spec.
+func (a Auth) CookieAuthEnabled() bool {
+	return a.CookieEnabled && a.ClientID == ""
+}
 
 // getPreferredIPAddress detects the most likely candidate IP address for this machine.
 // It prefers non-loopback IPv4 addresses and excludes link-local addresses.
@@ -155,11 +174,12 @@ func defaultConfig() *Config {
 			DisableCIRA:          true,
 		},
 		HTTP: HTTP{
-			Host:           "",
-			Port:           "8181",
-			AllowedOrigins: []string{"*"},
-			AllowedHeaders: []string{"*"},
-			WSCompression:  true,
+			Host:             "",
+			Port:             "8181",
+			AllowedOrigins:   []string{"*"},
+			AllowedHeaders:   []string{"*"},
+			AllowCredentials: false,
+			WSCompression:    true,
 			TLS: TLS{
 				Enabled:  true,
 				CertFile: "",
@@ -190,6 +210,10 @@ func defaultConfig() *Config {
 			JWTKey:                   "your_secret_jwt_key",
 			JWTExpiration:            24 * time.Hour,
 			RedirectionJWTExpiration: 5 * time.Minute,
+			CookieEnabled:            true,
+			CookieName:               DefaultSessionCookieName,
+			CookieSecure:             true,
+			CookieSameSite:           "strict",
 			// OAUTH CONFIG, if provided will not use basic auth
 			ClientID: "",
 			Issuer:   "",

--- a/integration-test/collections/console_environment.postman_environment.json
+++ b/integration-test/collections/console_environment.postman_environment.json
@@ -64,6 +64,11 @@
 			"value": "1.0.0",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -2603,6 +2603,68 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Session",
+			"item": [
+				{
+					"name": "Logout clears session cookies",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"// Public route: an expired session must still be able to clear its cookie.\r",
+									"pm.test(\"Session cookie is expired\", function () {\r",
+									"    var setCookie = pm.response.headers.all()\r",
+									"        .filter(function (h) { return h.key.toLowerCase() === \"set-cookie\"; })\r",
+									"        .map(function (h) { return h.value; });\r",
+									"\r",
+									"    var session = setCookie.filter(function (v) { return v.indexOf(\"console_session=\") === 0; });\r",
+									"\r",
+									"    pm.expect(session.length, \"session cookie cleared\").to.eql(1);\r",
+									"    pm.expect(session[0]).to.include(\"Max-Age=0\");\r",
+									"    pm.expect(session[0]).to.include(\"HttpOnly\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/authorize/logout",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authorize",
+								"logout"
+							]
+						},
+						"description": "Expires the HttpOnly session cookie.\n\nPOST /api/v1/authorize returns the token in the body (for Authorization: Bearer clients) and also sets it as an HttpOnly cookie, so browsers need not store it. The Authorization header takes precedence when both are present."
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [
@@ -2630,5 +2692,15 @@
 				]
 			}
 		}
-	]
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{token}}",
+				"type": "string"
+			}
+		]
+	}
 }

--- a/integration-test/collections/console_rps_apis.postman_collection.json
+++ b/integration-test/collections/console_rps_apis.postman_collection.json
@@ -8397,7 +8397,7 @@
 		"bearer": [
 			{
 				"key": "token",
-				"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NjUzOTU1OTl9.2cEjByEMSu7g_PQG8uj5kOTwzQ8D4lnuflx4Tb9ElCY",
+				"value": "{{token}}",
 				"type": "string"
 			}
 		]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 
 	"github.com/gin-contrib/cors"
@@ -80,6 +81,7 @@ func setupHTTPHandler(cfg *config.Config, log logger.Interface, usecases *usecas
 	defaultConfig := cors.DefaultConfig()
 	defaultConfig.AllowOrigins = cfg.AllowedOrigins
 	defaultConfig.AllowHeaders = cfg.AllowedHeaders
+	defaultConfig.AllowCredentials = cfg.AllowCredentials && !slices.Contains(cfg.AllowedOrigins, "*")
 
 	handler.Use(cors.New(defaultConfig))
 	httpapi.NewRouter(handler, log, *usecases, cfg)

--- a/internal/controller/httpapi/router.go
+++ b/internal/controller/httpapi/router.go
@@ -40,6 +40,8 @@ func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases, cfg 
 	// Public routes
 	login := v1.NewLoginRoute(cfg)
 	handler.POST("/api/v1/authorize", login.Login)
+	// Public so an expired session can still clear its cookies.
+	handler.POST("/api/v1/authorize/logout", login.Logout)
 
 	// Setup UI routes (no-op in noui builds)
 	setupUIRoutes(handler, l, cfg)

--- a/internal/controller/httpapi/v1/devices.go
+++ b/internal/controller/httpapi/v1/devices.go
@@ -83,7 +83,7 @@ func (dr *deviceRoutes) LoginRedirection(c *gin.Context) {
 
 	tokenString, err := token.SignedString([]byte(config.ConsoleConfig.JWTKey))
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{errorKey: "could not create token"})
+		c.JSON(http.StatusInternalServerError, gin.H{errorKey: errTokenCreation})
 
 		return
 	}

--- a/internal/controller/httpapi/v1/error.go
+++ b/internal/controller/httpapi/v1/error.go
@@ -20,9 +20,11 @@ import (
 
 // errorKey is the JSON field name used for error messages in gin.H responses.
 // messageKey is the JSON field name used for human-readable messages in gin.H responses.
+// errTokenCreation is returned when a JWT cannot be signed.
 const (
-	errorKey   = "error"
-	messageKey = "message"
+	errorKey         = "error"
+	messageKey       = "message"
+	errTokenCreation = "could not create token"
 )
 
 type response struct {

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -18,6 +18,14 @@ import (
 	"github.com/device-management-toolkit/console/pkg/consoleerrors"
 )
 
+const (
+	// sessionCookiePath covers both the UI (/) and the API (/api).
+	sessionCookiePath = "/"
+
+	authorizationHeader = "Authorization"
+	bearerPrefix        = "Bearer "
+)
+
 var (
 	ErrLogin                   = consoleerrors.CreateConsoleError("LoginHandler")
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
@@ -83,28 +91,43 @@ func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 
 	// Create JWT token
 	expirationTime := time.Now().Add(config.ConsoleConfig.JWTExpiration)
-	claims := jwt.RegisteredClaims{
-		ExpiresAt: jwt.NewNumericDate(expirationTime),
-		Issuer:    config.ConsoleConfig.Issuer,
+	claims := jwt.MapClaims{
+		"exp": expirationTime.Unix(),
+	}
+
+	// Conditional so the claim set still matches what callers saw before.
+	if config.ConsoleConfig.Issuer != "" {
+		claims["iss"] = config.ConsoleConfig.Issuer
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	tokenString, err := token.SignedString([]byte(lr.Config.JWTKey))
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{errorKey: "could not create token"})
+		c.JSON(http.StatusInternalServerError, gin.H{errorKey: errTokenCreation})
 
 		return
 	}
 
+	setSessionCookies(c, tokenString, expirationTime)
+
+	// Token stays in the body for bearer clients, which ignore Set-Cookie.
 	c.JSON(http.StatusOK, gin.H{"token": tokenString})
 }
 
-// JWT Middleware
+// Logout expires the session cookies. Public, so an already-expired session can
+// still clear its own. Not revocation: the JWT stays valid until it expires.
+func (lr LoginRoute) Logout(c *gin.Context) {
+	clearSessionCookies(c)
+
+	c.JSON(http.StatusOK, gin.H{messageKey: "logged out"})
+}
+
+// JWTAuthMiddleware accepts either the Authorization header (REST clients) or
+// the session cookie (browser). The header wins, so REST clients are unchanged.
 func (lr LoginRoute) JWTAuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		tokenString := c.GetHeader("Authorization")
-		tokenString = strings.Replace(tokenString, "Bearer ", "", 1)
+		tokenString := resolveToken(c)
 
 		if tokenString == "" {
 			c.JSON(http.StatusUnauthorized, gin.H{errorKey: "request does not contain an access token"})
@@ -113,34 +136,123 @@ func (lr LoginRoute) JWTAuthMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// if clientID is set, use the oidc verifier
-		if config.ConsoleConfig.ClientID != "" {
-			_, err := lr.Verifier.Verify(c.Request.Context(), tokenString)
-			if err != nil {
-				c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid access token"})
-				c.Abort()
+		if !lr.verifyToken(c, tokenString) {
+			c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid access token"})
+			c.Abort()
 
-				return
-			}
-		} else {
-			claims := &jwt.MapClaims{}
-
-			token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-					return nil, fmt.Errorf("%w: %v", ErrUnexpectedSigningMethod, token.Header["alg"])
-				}
-
-				return []byte(lr.Config.JWTKey), nil
-			})
-
-			if err != nil || !token.Valid {
-				c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid access token"})
-				c.Abort()
-
-				return
-			}
+			return
 		}
 
 		c.Next()
 	}
+}
+
+// resolveToken prefers the Authorization header, falling back to the cookie.
+func resolveToken(c *gin.Context) string {
+	if header := c.GetHeader(authorizationHeader); header != "" {
+		return strings.Replace(header, bearerPrefix, "", 1)
+	}
+
+	if !cookieAuthEnabled() {
+		return ""
+	}
+
+	cookie, err := c.Cookie(sessionCookieName())
+	if err != nil {
+		return ""
+	}
+
+	return cookie
+}
+
+// verifyToken reports whether the token is valid.
+func (lr LoginRoute) verifyToken(c *gin.Context, tokenString string) bool {
+	// if clientID is set, use the oidc verifier
+	if config.ConsoleConfig.ClientID != "" {
+		_, err := lr.Verifier.Verify(c.Request.Context(), tokenString)
+
+		return err == nil
+	}
+
+	claims := &jwt.MapClaims{}
+
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("%w: %v", ErrUnexpectedSigningMethod, token.Header["alg"])
+		}
+
+		return []byte(lr.Config.JWTKey), nil
+	})
+
+	return err == nil && token.Valid
+}
+
+// cookieAuthEnabled reports whether session cookies are in use. An unconfigured
+// process issues none.
+func cookieAuthEnabled() bool {
+	if config.ConsoleConfig == nil {
+		return false
+	}
+
+	return config.ConsoleConfig.CookieAuthEnabled()
+}
+
+func sessionCookieName() string {
+	if config.ConsoleConfig.CookieName != "" {
+		return config.ConsoleConfig.CookieName
+	}
+
+	return config.DefaultSessionCookieName
+}
+
+func cookieSameSite() http.SameSite {
+	switch strings.ToLower(config.ConsoleConfig.CookieSameSite) {
+	case "none":
+		return http.SameSiteNoneMode
+	case "lax":
+		return http.SameSiteLaxMode
+	default:
+		return http.SameSiteStrictMode
+	}
+}
+
+// setSessionCookies issues the JWT as an HttpOnly cookie, so the browser need
+// not persist it in Web Storage.
+func setSessionCookies(c *gin.Context, tokenString string, expiresAt time.Time) {
+	if !cookieAuthEnabled() {
+		return
+	}
+
+	writeSessionCookie(c, tokenString, int(time.Until(expiresAt).Seconds()))
+}
+
+// clearSessionCookies expires the cookie, even when cookie auth is now off, so
+// one issued earlier can still be cleaned up.
+func clearSessionCookies(c *gin.Context) {
+	writeSessionCookie(c, "", -1)
+}
+
+func writeSessionCookie(c *gin.Context, tokenString string, maxAge int) {
+	if config.ConsoleConfig == nil {
+		return
+	}
+
+	secure := config.ConsoleConfig.CookieSecure
+	sameSite := cookieSameSite()
+
+	// Browsers drop SameSite=None cookies that are not Secure.
+	if sameSite == http.SameSiteNoneMode {
+		secure = true
+	}
+
+	//nolint:gosec // G124: Secure and SameSite are set from config above; the linter cannot see through the variables
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     sessionCookieName(),
+		Value:    tokenString,
+		Path:     sessionCookiePath,
+		MaxAge:   maxAge,
+		Secure:   secure,
+		HttpOnly: true,
+		SameSite: sameSite,
+	})
 }

--- a/internal/controller/httpapi/v1/login_test.go
+++ b/internal/controller/httpapi/v1/login_test.go
@@ -6,12 +6,248 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
 	"github.com/device-management-toolkit/console/config"
 )
+
+const (
+	testJWTKey       = "test-jwt-key"
+	testAdminUser    = "admin"
+	testAdminPass    = "secret"
+	testCredsBody    = `{"username":"admin","password":"secret"}`
+	testProtectedURL = "/api/v1/devices"
+	testAuthorizeURL = "/api/v1/authorize"
+	testLogoutURL    = "/api/v1/authorize/logout"
+)
+
+// cookieAuthTestConfig is a basic-auth (non-OIDC) config with cookies enabled.
+func cookieAuthTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.AdminUsername = testAdminUser
+	cfg.AdminPassword = testAdminPass
+	cfg.JWTKey = testJWTKey
+	cfg.JWTExpiration = time.Hour
+	cfg.CookieEnabled = true
+	cfg.CookieName = config.DefaultSessionCookieName
+	cfg.CookieSecure = true
+	cfg.CookieSameSite = "strict"
+
+	return cfg
+}
+
+// newAuthTestEngine wires authorize, logout and one protected route against cfg,
+// installing it as the singleton the handlers read.
+func newAuthTestEngine(t *testing.T, cfg *config.Config) *gin.Engine {
+	t.Helper()
+
+	prev := config.ConsoleConfig
+
+	t.Cleanup(func() { config.ConsoleConfig = prev })
+
+	config.ConsoleConfig = cfg
+
+	route := LoginRoute{Config: cfg}
+
+	engine := gin.New()
+	engine.POST(testAuthorizeURL, route.Login)
+	engine.POST(testLogoutURL, route.Logout)
+	engine.GET(testProtectedURL, route.JWTAuthMiddleware(), func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	return engine
+}
+
+// login authorizes and returns the body token plus the cookies set, by name.
+func login(t *testing.T, engine *gin.Engine) (token string, cookies map[string]*http.Cookie) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, testAuthorizeURL, bytes.NewBufferString(testCredsBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]string
+
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	cookies = make(map[string]*http.Cookie)
+	for _, cookie := range w.Result().Cookies() {
+		cookies[cookie.Name] = cookie
+	}
+
+	return body["token"], cookies
+}
+
+// get calls the protected route after applying mutators.
+func get(t *testing.T, engine *gin.Engine, mutators ...func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, testProtectedURL, http.NoBody)
+	require.NoError(t, err)
+
+	for _, mutate := range mutators {
+		mutate(req)
+	}
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	return w
+}
+
+func withBearer(token string) func(*http.Request) {
+	return func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+token) }
+}
+
+func withCookie(cookie *http.Cookie) func(*http.Request) {
+	return func(r *http.Request) { r.AddCookie(cookie) }
+}
+
+// TestAuthorizeIssuesSessionCookies pins the shape REST clients rely on: the
+// token stays in the body and the cookies are purely additive.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestAuthorizeIssuesSessionCookies(t *testing.T) {
+	engine := newAuthTestEngine(t, cookieAuthTestConfig())
+
+	token, cookies := login(t, engine)
+	require.NotEmpty(t, token, "token must remain in the response body for bearer clients")
+
+	session, ok := cookies[config.DefaultSessionCookieName]
+	require.True(t, ok, "expected the session cookie to be set")
+	require.Equal(t, token, session.Value, "session cookie must carry the same token as the body")
+	require.True(t, session.HttpOnly, "session cookie must not be readable by script")
+	require.True(t, session.Secure)
+	require.Equal(t, http.SameSiteStrictMode, session.SameSite)
+	require.Equal(t, "/", session.Path)
+	require.Positive(t, session.MaxAge)
+
+	require.Len(t, cookies, 1, "only the session cookie is issued")
+}
+
+// TestBearerAuthUnchanged is the backward-compatibility guarantee for curl,
+// Postman and partner tooling: a bearer header authenticates on its own.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestBearerAuthUnchanged(t *testing.T) {
+	engine := newAuthTestEngine(t, cookieAuthTestConfig())
+
+	token, cookies := login(t, engine)
+
+	t.Run("bearer header alone is accepted", func(t *testing.T) {
+		require.Equal(t, http.StatusOK, get(t, engine, withBearer(token)).Code)
+	})
+
+	t.Run("bearer header is accepted alongside a cookie", func(t *testing.T) {
+		session := cookies[config.DefaultSessionCookieName]
+
+		w := get(t, engine, withBearer(token), withCookie(session))
+		require.Equal(t, http.StatusOK, w.Code, "header takes precedence over the cookie")
+	})
+
+	t.Run("no credentials at all is still 401", func(t *testing.T) {
+		require.Equal(t, http.StatusUnauthorized, get(t, engine).Code)
+	})
+}
+
+// TestCookieAuthAcceptsSessionCookie covers the cookie path on its own.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestCookieAuthAcceptsSessionCookie(t *testing.T) {
+	engine := newAuthTestEngine(t, cookieAuthTestConfig())
+
+	_, cookies := login(t, engine)
+	session := cookies[config.DefaultSessionCookieName]
+
+	t.Run("session cookie alone is accepted", func(t *testing.T) {
+		require.Equal(t, http.StatusOK, get(t, engine, withCookie(session)).Code)
+	})
+
+	t.Run("a tampered session cookie is rejected", func(t *testing.T) {
+		forged := &http.Cookie{Name: session.Name, Value: session.Value + "x"}
+		require.Equal(t, http.StatusUnauthorized, get(t, engine, withCookie(forged)).Code)
+	})
+}
+
+// TestCookieAuthDisabled checks the escape hatch: with cookies off, none are
+// issued and an earlier one no longer authenticates.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestCookieAuthDisabled(t *testing.T) {
+	enabled := newAuthTestEngine(t, cookieAuthTestConfig())
+	_, cookies := login(t, enabled)
+	session := cookies[config.DefaultSessionCookieName]
+
+	cfg := cookieAuthTestConfig()
+	cfg.CookieEnabled = false
+	disabled := newAuthTestEngine(t, cfg)
+
+	token, issued := login(t, disabled)
+	require.NotEmpty(t, token, "the body token is the only credential when cookies are off")
+	require.Empty(t, issued, "no cookies should be issued when cookie auth is disabled")
+
+	w := get(t, disabled, withCookie(session))
+	require.Equal(t, http.StatusUnauthorized, w.Code, "a previously issued cookie must not authenticate")
+
+	require.Equal(t, http.StatusOK, get(t, disabled, withBearer(token)).Code)
+}
+
+// TestLogoutWithoutConfig: the public logout route must not panic when the
+// config singleton has not been populated yet.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestLogoutWithoutConfig(t *testing.T) {
+	prev := config.ConsoleConfig
+
+	t.Cleanup(func() { config.ConsoleConfig = prev })
+
+	config.ConsoleConfig = nil
+
+	engine := gin.New()
+	route := LoginRoute{Config: &config.Config{}}
+	engine.POST(testLogoutURL, route.Logout)
+
+	req, err := http.NewRequest(http.MethodPost, testLogoutURL, http.NoBody)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+
+	require.NotPanics(t, func() { engine.ServeHTTP(w, req) })
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Empty(t, w.Result().Cookies(), "no cookie can be written without config")
+}
+
+// TestLogoutExpiresSessionCookie checks the cookie is cleared and that logout
+// works without credentials.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestLogoutExpiresSessionCookie(t *testing.T) {
+	engine := newAuthTestEngine(t, cookieAuthTestConfig())
+
+	req, err := http.NewRequest(http.MethodPost, testLogoutURL, http.NoBody)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "logout must work without a valid session")
+
+	cleared := make(map[string]*http.Cookie)
+	for _, cookie := range w.Result().Cookies() {
+		cleared[cookie.Name] = cookie
+	}
+
+	cookie, ok := cleared[config.DefaultSessionCookieName]
+	require.True(t, ok, "expected the session cookie to be expired")
+	require.Empty(t, cookie.Value)
+	require.Negative(t, cookie.MaxAge)
+}
 
 func TestLogin_InvalidCredentialsReturnsMessage(t *testing.T) {
 	t.Parallel()

--- a/internal/controller/openapi/adapter.go
+++ b/internal/controller/openapi/adapter.go
@@ -20,6 +20,9 @@ const (
 	defaultTenantID   = "default"
 	exampleDeviceGUID = "example-guid-1"
 	exampleDeviceHost = "device1.example.com"
+
+	bearerAuthScheme = "bearerAuth"
+	cookieAuthScheme = "cookieAuth"
 )
 
 type FuegoAdapter struct {
@@ -31,14 +34,7 @@ type FuegoAdapter struct {
 func NewFuegoAdapter(usecases usecase.Usecases, log logger.Interface) *FuegoAdapter {
 	server := fuego.NewServer(
 		fuego.WithoutStartupMessages(),
-		fuego.WithSecurity(openapi3.SecuritySchemes{
-			"bearerAuth": &openapi3.SecuritySchemeRef{
-				Value: openapi3.NewSecurityScheme().
-					WithType("http").
-					WithScheme("bearer").
-					WithBearerFormat("JWT"),
-			},
-		}),
+		fuego.WithSecurity(securitySchemes()),
 	)
 
 	return &FuegoAdapter{
@@ -46,6 +42,36 @@ func NewFuegoAdapter(usecases usecase.Usecases, log logger.Interface) *FuegoAdap
 		usecases: usecases,
 		logger:   log,
 	}
+}
+
+// securitySchemes declares only the mechanisms the server actually accepts, so
+// cookieAuth is omitted where the middleware would ignore a cookie.
+func securitySchemes() openapi3.SecuritySchemes {
+	schemes := openapi3.SecuritySchemes{
+		bearerAuthScheme: &openapi3.SecuritySchemeRef{
+			Value: openapi3.NewSecurityScheme().
+				WithType("http").
+				WithScheme("bearer").
+				WithBearerFormat("JWT"),
+		},
+	}
+
+	if !specCookieAuthEnabled() {
+		return schemes
+	}
+
+	// The name is the default; a build-time spec cannot know a runtime override.
+	schemes[cookieAuthScheme] = &openapi3.SecuritySchemeRef{
+		Value: openapi3.NewSecurityScheme().
+			WithType("apiKey").
+			WithIn("cookie").
+			WithName(config.DefaultSessionCookieName).
+			WithDescription("Session cookie issued by POST /api/v1/authorize. Named `" +
+				config.DefaultSessionCookieName + "` by default; a deployment may override it with " +
+				"`auth.cookieName`."),
+	}
+
+	return schemes
 }
 
 // Registers API routes with Fuego for automatic OpenAPI generation.

--- a/internal/controller/openapi/devices.go
+++ b/internal/controller/openapi/devices.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-fuego/fuego"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 )
 
@@ -21,8 +22,21 @@ func (f *FuegoAdapter) registerDeviceAuthRoutes() {
 	fuego.Post(f.server, "/api/v1/authorize", f.login,
 		fuego.OptionTags("Devices"),
 		fuego.OptionSummary("Authorize"),
-		fuego.OptionDescription("Authenticate and return an access token"),
+		fuego.OptionDescription("Authenticate and return an access token.\n\n"+
+			"The token is returned in the body for `Authorization: Bearer` clients, and also "+
+			"set as an HttpOnly session cookie so browsers need not store it. The cookie is "+
+			"named `"+config.DefaultSessionCookieName+"` unless the deployment overrides "+
+			"`auth.cookieName`, and is not issued at all when cookie auth is disabled or "+
+			"OIDC is configured."),
 		fuego.OptionAddResponse(http.StatusUnauthorized, "Unauthorized: invalid credentials", fuego.Response{Type: ErrorResponse{}}),
+	)
+
+	fuego.Post(f.server, "/api/v1/authorize/logout", f.logout,
+		fuego.OptionTags("Devices"),
+		fuego.OptionSummary("Logout"),
+		fuego.OptionDescription("Expire the session cookie.\n\n"+
+			"Public, so an already-expired session can still clear it. Not revocation: "+
+			"the JWT is stateless and stays valid until it expires."),
 	)
 
 	fuego.Get(f.server, "/api/v1/authorize/redirection/{id}", f.loginRedirection,
@@ -147,6 +161,15 @@ func (f *FuegoAdapter) login(c fuego.ContextWithBody[dto.Credentials]) (Authoriz
 
 func (f *FuegoAdapter) loginRedirection(_ fuego.ContextNoBody) (AuthorizeRedirectionResponse, error) {
 	return AuthorizeRedirectionResponse{Token: "example-token"}, nil
+}
+
+// LogoutResponse acknowledges that the session cookie was expired.
+type LogoutResponse struct {
+	Message string `json:"message" example:"logged out"`
+}
+
+func (f *FuegoAdapter) logout(_ fuego.ContextNoBody) (LogoutResponse, error) {
+	return LogoutResponse{Message: "logged out"}, nil
 }
 
 func (f *FuegoAdapter) getDevices(_ fuego.ContextNoBody) (dto.DeviceCountResponse, error) {
@@ -281,21 +304,21 @@ func (f *FuegoAdapter) getTags(_ fuego.ContextNoBody) ([]string, error) {
 }
 
 func (f *FuegoAdapter) createDevice(c fuego.ContextWithBody[dto.Device]) (dto.Device, error) {
-	config, err := c.Body()
+	device, err := c.Body()
 	if err != nil {
 		return dto.Device{}, err
 	}
 
-	return config, nil
+	return device, nil
 }
 
 func (f *FuegoAdapter) updateDevice(c fuego.ContextWithBody[dto.Device]) (dto.Device, error) {
-	config, err := c.Body()
+	device, err := c.Body()
 	if err != nil {
 		return dto.Device{}, err
 	}
 
-	return config, nil
+	return device, nil
 }
 
 func (f *FuegoAdapter) deleteDevice(_ fuego.ContextNoBody) (NoContentResponse, error) {

--- a/internal/controller/openapi/route_options.go
+++ b/internal/controller/openapi/route_options.go
@@ -5,7 +5,19 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-fuego/fuego"
+
+	"github.com/device-management-toolkit/console/config"
 )
+
+// specCookieAuthEnabled mirrors the auth middleware. cmd/openapi-gen runs
+// without config, so nil documents the shipped defaults.
+func specCookieAuthEnabled() bool {
+	if config.ConsoleConfig == nil {
+		return true
+	}
+
+	return config.ConsoleConfig.CookieAuthEnabled()
+}
 
 func apiRouteOptions() fuego.RouteOption {
 	return routeOptionGroup(
@@ -14,9 +26,18 @@ func apiRouteOptions() fuego.RouteOption {
 }
 
 func protectedRouteOptions() fuego.RouteOption {
+	// Alternatives, not both: a bearer header or the session cookie.
+	security := []openapi3.SecurityRequirement{
+		{bearerAuthScheme: []string{}},
+	}
+
+	if specCookieAuthEnabled() {
+		security = append(security, openapi3.SecurityRequirement{cookieAuthScheme: []string{}})
+	}
+
 	return routeOptionGroup(
 		apiRouteOptions(),
-		fuego.OptionSecurity(openapi3.SecurityRequirement{"bearerAuth": []string{}}),
+		fuego.OptionSecurity(security...),
 		errorResponseOption(http.StatusNotFound, "Not Found"),
 		errorResponseOption(http.StatusRequestTimeout, "Request Timeout"),
 		errorResponseOption(http.StatusConflict, "Conflict"),


### PR DESCRIPTION
A security review flagged the browser client persisting its session JWT in localStorage, where any script on the page can read it. Console now also issues the token as an HttpOnly cookie so the browser no longer needs a readable copy.

The change is additive. POST /api/v1/authorize still returns the token in the response body, and JWTAuthMiddleware still reads the Authorization header first, falling back to the cookie only when no header is present. curl, Postman collections and partner tooling are therefore unaffected, which keeps the /api/v1/* MPS+RPS contract intact.

- add POST /api/v1/authorize/logout, public so an already-expired session can still clear its cookie
- add auth.cookieEnabled / cookieName / cookieSecure / cookieSameSite, defaulting to an HttpOnly, Secure, SameSite=Strict cookie
- add http.allow_credentials for cross-origin browser clients; it is ignored while allowed_origins is the "*" wildcard, which CORS forbids pairing with credentials
- skip cookies entirely under OIDC, where the IdP library owns the token and Console mints none

SameSite=Strict is currently the only CSRF defence on the cookie path. Setting cookieSameSite to "none" removes it; that is noted in .env.example and a startup guard is left to a follow-up.

Logout expires the cookie but is not revocation: the JWT is stateless and stays valid until it expires.