### PR TITLE
fix(auth): enforce required JWT key to prevent forged token attacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,8 @@ EA_PASSWORD=
 AUTH_DISABLED=false
 AUTH_ADMIN_USERNAME=standalone
 # AUTH_ADMIN_PASSWORD: uncomment this line to set your own password; otherwise Console generates one in config.yml
-AUTH_JWT_KEY=your_secret_jwt_key
+# Required when AUTH_DISABLED=false. Set a strong, unique signing secret.
+AUTH_JWT_KEY=
 AUTH_JWT_EXPIRATION=24h
 AUTH_REDIRECTION_JWT_EXPIRATION=5m
 # Ignored when AUTH_CLIENT_ID is set (OIDC).

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ var TrayMode bool
 var (
 	ErrJWTExpirationInvalid            = errors.New("config: auth.jwtExpiration must be at least 1 minute (e.g. 24h) — very short expirations render tokens unusable")
 	ErrRedirectionJWTExpirationInvalid = errors.New("config: auth.redirectionJWTExpiration must be at least 1 minute (e.g. 5m) — very short expirations render redirection tokens unusable")
+	ErrJWTKeyMissing                   = errors.New("config: auth.jwtKey is required — set AUTH_JWT_KEY environment variable or jwtKey in config.yml to a strong secret")
 )
 
 const defaultHost = "localhost"
@@ -224,7 +225,7 @@ func defaultConfig() *Config {
 		Auth: Auth{
 			AdminUsername:            "standalone",
 			AdminPassword:            "", // Generated and stored in config on first run if not provided
-			JWTKey:                   "your_secret_jwt_key",
+			JWTKey:                   "",
 			JWTExpiration:            24 * time.Hour,
 			RedirectionJWTExpiration: 5 * time.Minute,
 			CookieEnabled:            true,
@@ -416,6 +417,10 @@ func (c *Config) validate() error {
 
 	if c.RedirectionJWTExpiration < time.Minute {
 		return ErrRedirectionJWTExpirationInvalid
+	}
+
+	if c.JWTKey == "" {
+		return ErrJWTKeyMissing
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -419,7 +419,7 @@ func (c *Config) validate() error {
 		return ErrRedirectionJWTExpirationInvalid
 	}
 
-	if c.JWTKey == "" {
+	if !c.Disabled && c.JWTKey == "" {
 		return ErrJWTKeyMissing
 	}
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -39,7 +39,8 @@ auth:
   disabled: false
   adminUsername: standalone
   adminPassword: 
-  jwtKey: your_secret_jwt_key
+  # Required when auth is enabled. Set a strong, unique signing secret.
+  jwtKey: ""
   jwtExpiration: 24h0m0s
   redirectionJWTExpiration: 5m0s
   clientId: ""

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,10 +17,12 @@ func clearEnv() {
 	os.Unsetenv("LOG_LEVEL")
 	os.Unsetenv("DB_POOL_MAX")
 	os.Unsetenv("DB_URL")
+	os.Unsetenv("AUTH_JWT_KEY")
 }
 
-func TestNewConfig_Defaults(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
+func TestNewConfig_Defaults(t *testing.T) {
 	clearEnv() // Clear environment variables to ensure defaults are tested
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key-for-default-testing")
 
 	cfg, err := NewConfig()
 
@@ -47,7 +49,7 @@ func TestNewConfig_Defaults(t *testing.T) { //nolint:paralleltest // cannot have
 	assert.Equal(t, 2, cfg.PoolMax)
 }
 
-func TestNewConfig_EnvVars(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
+func TestNewConfig_EnvVars(t *testing.T) {
 	// Set environment variables
 	os.Setenv("APP_NAME", "testApp")
 	os.Setenv("HTTP_PORT", "9090")
@@ -55,6 +57,7 @@ func TestNewConfig_EnvVars(t *testing.T) { //nolint:paralleltest // cannot have 
 	os.Setenv("DB_POOL_MAX", "10")
 	os.Setenv("DB_URL", "postgres://user:password@localhost:5432/testdb")
 	os.Setenv("HTTP_TLS_ENABLED", "false")
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key-for-env-testing")
 
 	defer clearEnv() // Ensure environment variables are cleared after test
 
@@ -304,7 +307,7 @@ func TestWriteConfig_TightensExistingLooseFile(t *testing.T) {
 	assert.Equal(t, configFilePerm, fileInfo.Mode().Perm())
 }
 
-func TestNewConfig_FileAndEnvVars(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
+func TestNewConfig_FileAndEnvVars(t *testing.T) {
 	clearEnv() // Clear environment variables before setting new ones
 
 	// Create a temporary config file
@@ -331,6 +334,7 @@ postgres:
 	os.Setenv("LOG_LEVEL", "debug")
 	os.Setenv("DB_POOL_MAX", "10")
 	os.Setenv("DB_URL", "postgres://envuser:envpassword@localhost:5432/envdb")
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key-for-file-and-env-testing")
 
 	defer clearEnv() // Ensure environment variables are cleared after test
 
@@ -384,6 +388,7 @@ func TestValidatePort(t *testing.T) {
 func TestNewConfig_InvalidPort(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
 	clearEnv()
 	os.Setenv("HTTP_PORT", "not-a-port")
+	os.Setenv("AUTH_JWT_KEY", "test-jwt-key-for-invalid-port-testing")
 
 	defer clearEnv()
 
@@ -394,6 +399,7 @@ func TestNewConfig_InvalidPort(t *testing.T) { //nolint:paralleltest // cannot h
 func TestNewConfig_PortOutOfRange(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying environment variables
 	clearEnv()
 	os.Setenv("HTTP_PORT", "70000")
+	os.Setenv("AUTH_JWT_KEY", "test-jwt-key-for-port-out-of-range-testing")
 
 	defer clearEnv()
 
@@ -467,6 +473,26 @@ func TestValidate_NegativeRedirectionJWTExpiration(t *testing.T) {
 	require.ErrorIs(t, err, ErrRedirectionJWTExpirationInvalid)
 }
 
+func TestValidate_MissingJWTKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.JWTKey = ""
+
+	err := cfg.validate()
+	require.ErrorIs(t, err, ErrJWTKeyMissing)
+}
+
+func TestValidate_JWTKeyPresent(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.JWTKey = "test-jwt-key"
+
+	err := cfg.validate()
+	require.NoError(t, err)
+}
+
 func TestValidate_SubMinuteRedirectionJWTExpiration(t *testing.T) {
 	t.Parallel()
 
@@ -481,6 +507,7 @@ func TestValidate_ValidDefaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := defaultConfig()
+	cfg.JWTKey = "test-jwt-key-for-validation"
 
 	err := cfg.validate()
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -483,6 +483,16 @@ func TestValidate_MissingJWTKey(t *testing.T) {
 	require.ErrorIs(t, err, ErrJWTKeyMissing)
 }
 
+func TestValidate_AuthDisabledAllowsMissingJWTKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.Disabled = true
+
+	err := cfg.validate()
+	require.NoError(t, err)
+}
+
 func TestValidate_JWTKeyPresent(t *testing.T) {
 	t.Parallel()
 

--- a/config/encryption_key_test.go
+++ b/config/encryption_key_test.go
@@ -87,6 +87,7 @@ func TestNewConfig_RejectsInvalidEncryptionKey(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("APP_ENCRYPTION_KEY", tc.key)
+			t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 			cfg, err := NewConfig()
 
@@ -101,6 +102,7 @@ func TestNewConfig_RejectsInvalidEncryptionKey(t *testing.T) {
 func TestNewConfig_AcceptsValidEncryptionKey(t *testing.T) {
 	clearEnv()
 	t.Setenv("APP_ENCRYPTION_KEY", "Jf3Q2nXJ+GZzN1dbVQms0wbB4+i/5PjL")
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 	cfg, err := NewConfig()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -85,8 +85,8 @@ func TestSetupHTTPHandlerSetsNoSniffAheadOfCORS(t *testing.T) {
 	}
 }
 
-func TestRun(t *testing.T) {
-	t.Parallel()
+func TestRun(t *testing.T) { //nolint:tparallel // t.Setenv is incompatible with t.Parallel, so this test can't mark itself parallel even though its subtest does
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 	ctrl := gomock.NewController(t)
 

--- a/internal/controller/ws/v1/redirect_test.go
+++ b/internal/controller/ws/v1/redirect_test.go
@@ -22,9 +22,11 @@ var (
 	ErrRedirect = errors.New("redirection error")
 )
 
-func TestWebSocketHandler(t *testing.T) { //nolint:paralleltest // logging library is not thread-safe for tests
+func TestWebSocketHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
+
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 	_, _ = config.NewConfig()
 
@@ -103,14 +105,15 @@ func TestWebSocketHandler(t *testing.T) { //nolint:paralleltest // logging libra
 }
 
 // TestWebSocketHandlerDeviceBinding: WS accepts only a token whose deviceId matches host.
-func TestWebSocketHandlerDeviceBinding(t *testing.T) { //nolint:paralleltest // logging library is not thread-safe for tests
+func TestWebSocketHandlerDeviceBinding(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
+
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 	_, _ = config.NewConfig()
 
 	config.ConsoleConfig.Disabled = false
-	config.ConsoleConfig.JWTKey = "test-jwt-key"
 
 	// deviceID == "" mimics a login token (no deviceId claim).
 	tokenFor := func(deviceID string) string {
@@ -230,14 +233,15 @@ func TestWebSocketHandlerDeviceBinding(t *testing.T) { //nolint:paralleltest // 
 }
 
 // TestWebSocketHandlerTokenValidation: WS rejects missing and unverifiable tokens.
-func TestWebSocketHandlerTokenValidation(t *testing.T) { //nolint:paralleltest // logging library is not thread-safe for tests
+func TestWebSocketHandlerTokenValidation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
+
+	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
 	_, _ = config.NewConfig()
 
 	config.ConsoleConfig.Disabled = false
-	config.ConsoleConfig.JWTKey = "test-jwt-key"
 
 	signedWith := func(key string, expiry time.Time) string {
 		claims := jwt.MapClaims{

--- a/internal/controller/ws/v1/redirect_test.go
+++ b/internal/controller/ws/v1/redirect_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/device-management-toolkit/console/config"
@@ -28,7 +29,8 @@ func TestWebSocketHandler(t *testing.T) {
 
 	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
-	_, _ = config.NewConfig()
+	_, err := config.NewConfig()
+	require.NoError(t, err)
 
 	config.ConsoleConfig.Disabled = true
 	mockFeature := mocks.NewMockDeviceManagementFeature(ctrl)
@@ -111,7 +113,8 @@ func TestWebSocketHandlerDeviceBinding(t *testing.T) {
 
 	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
-	_, _ = config.NewConfig()
+	_, err := config.NewConfig()
+	require.NoError(t, err)
 
 	config.ConsoleConfig.Disabled = false
 
@@ -239,7 +242,8 @@ func TestWebSocketHandlerTokenValidation(t *testing.T) {
 
 	t.Setenv("AUTH_JWT_KEY", "test-jwt-key")
 
-	_, _ = config.NewConfig()
+	_, err := config.NewConfig()
+	require.NoError(t, err)
 
 	config.ConsoleConfig.Disabled = false
 


### PR DESCRIPTION
Console shipped with a hardcoded default JWT signing key (your_secret_jwt_key), so any deployment that didn't override it could have session tokens forged by anyone who read the source. This removes the default and makes auth.jwtKey a required setting — NewConfig() now fails fast at startup with ErrJWTKeyMissing if AUTH_JWT_KEY (or jwtKey in config.yml) isn't set.

Also updates existing tests that called NewConfig() without a key (they broke once it became required) and adds coverage for the new validation branch.