### PR TITLE
refactor: clarify device GUID fuzz assertion

### DIFF
--- a/internal/usecase/devices/transform_fuzz_test.go
+++ b/internal/usecase/devices/transform_fuzz_test.go
@@ -131,7 +131,7 @@ func verifyDTOToEntity(t *testing.T, uc *UseCase, guid, certHash string, buildDT
 		t.Fatalf("dtoToEntity result mismatch")
 	}
 
-	if !strings.EqualFold(firstEntity.GUID, guid) {
+	if strings.Compare(firstEntity.GUID, strings.ToLower(guid)) != 0 {
 		t.Fatalf("dtoToEntity did not lowercase GUID")
 	}
 


### PR DESCRIPTION
This refactors the fuzz assertion to verify the exact behavior implemented by dtoToEntity: the GUID must equal strings.ToLower(guid). The previous strings.EqualFold comparison was too permissive and did not actually confirm that the returned GUID was lowercase, especially for Unicode inputs. No production behavior is changed.