### PR TITLE
fix: stop one slow device from blocking the others

### DIFF
--- a/internal/usecase/devices/wsman/message.go
+++ b/internal/usecase/devices/wsman/message.go
@@ -133,8 +133,7 @@ func (g GoWSMANMessages) Worker() {
 	for {
 		select {
 		case request := <-requestQueue:
-			request()
-			time.Sleep(queueTickTime)
+			go request()
 		case <-shutdownSignal:
 			return
 		}


### PR DESCRIPTION
The worker ran each connection setup inline, so one stuck device held the only goroutine and the rest queued behind it.

Steps to reproduce:
1. Set disable_cira: true and start Console.
2. Add a real vPro device that works.
3. Add a dummy device with an unreachable IP (any IP on your subnet with no AMT).
4. Open the dummy device's details page. Leave it loading.
5. Go back to the device list and open the real device's details.

Behavior: 
Before:
Opening one device's details while another device was still loading (or was unreachable) left the second device stuck. Its calls sat behind the first one and either returned very late or timed out with 504. Every device shared a single goroutine, so one bad device slowed all of them.

After fix:
Each device's connection setup runs on its own goroutine. An unreachable device still fails on its own, but other devices load normally at the same time.

Fixes https://github.com/device-management-toolkit/console/issues/1247