### PR TITLE
ci: pin release Go version to go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=1.23.0"
+          go-version-file: go.mod
 
       - name: Install `@semantic-release/exec` plugin
         run: npm install @semantic-release/exec @semantic-release/changelog
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=1.23.0"
+          go-version-file: go.mod
 
       - name: Version
         run: echo "The next version is $VERSION"


### PR DESCRIPTION
setup-go satisfied ">=1.23.0" with the runner's pre-installed Go 1.26.7 and GOTOOLCHAIN=local was in effect, so the release build failed against the go 1.27.0 directive in go.mod. Read the version from go.mod instead, as ci.yml already does, so a future bump of the go directive cannot desync the release job.