### PR TITLE
fix(api): restore struct validation on PATCH endpoints

### DIFF
--- a/internal/controller/httpapi/v1/devicemanagement_test.go
+++ b/internal/controller/httpapi/v1/devicemanagement_test.go
@@ -460,6 +460,7 @@ func TestDeviceManagement(t *testing.T) {
 			requestBody: map[string]interface{}{
 				"isTrusted": true,
 			},
+			// The binding validator rejects the body, so the feature is never called.
 			mock: func(m *mocks.MockDeviceManagementFeature) {
 				m.EXPECT().AddCertificate(
 					context.Background(),
@@ -467,7 +468,7 @@ func TestDeviceManagement(t *testing.T) {
 					gomock.Any(),
 				).Return("", ErrGeneral).AnyTimes()
 			},
-			expectedCode: http.StatusInternalServerError,
+			expectedCode: http.StatusBadRequest,
 			response:     nil,
 		},
 		{

--- a/internal/controller/httpapi/v1/devices.go
+++ b/internal/controller/httpapi/v1/devices.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/device-management-toolkit/console/config"
@@ -308,7 +309,9 @@ func (dr *deviceRoutes) update(c *gin.Context) {
 	}
 
 	var device dto.Device
-	if err := json.Unmarshal(body, &device); err != nil {
+	// BindBody decodes and runs the struct validators. Plain json.Unmarshal
+	// would skip them, letting an invalid device through on PATCH.
+	if err := binding.JSON.BindBody(body, &device); err != nil {
 		ErrorResponse(c, err)
 
 		return

--- a/internal/controller/httpapi/v1/devices_test.go
+++ b/internal/controller/httpapi/v1/devices_test.go
@@ -887,3 +887,22 @@ func verifyRedirectionToken(t *testing.T, tokenString, expectedDeviceID string) 
 	require.True(t, timeDiff < maxWrongExpiration-time.Hour,
 		"token expiration time %v is suspiciously close to 24 hours (the bug)", timeDiff)
 }
+
+// PATCH binds through the validator, so a body that violates the struct tags is
+// rejected before the feature is reached.
+func TestDevicesUpdatePatchRejectsInvalidBody(t *testing.T) {
+	t.Parallel()
+
+	// No mock expectations: reaching the feature would fail the test.
+	_, engine := devicesTest(t)
+
+	body := []byte(`{"guid":"valid-guid","username":"a-username-longer-than-sixteen"}`)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, "/api/v1/devices", bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/controller/httpapi/v1/domains_test.go
+++ b/internal/controller/httpapi/v1/domains_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -18,10 +20,27 @@ import (
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
 
+// The handler tests bind real request bodies, so the package needs the validator
+// setup NewRouter installs. Registration has to finish before the first parallel
+// test serves a request: the engine's tag map is not safe for concurrent use, so
+// registering from an engine built inside a parallel subtest would race a request
+// being validated in another.
+//
 //nolint:gochecknoinits // required to avoid issues when running tests in parallel
 func init() {
 	gin.SetMode(gin.TestMode)
-	gin.DisableBindValidation()
+
+	log := logger.New("error")
+
+	registerProfileValidators()
+	registerWirelessValidators(log)
+	registerIEEE8021xValidators(log)
+
+	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
+		_ = v.RegisterValidation("alphanumhyphenunderscore", dto.ValidateAlphaNumHyphenUnderscore)
+		_ = v.RegisterValidation("wifistate", dto.ValidateWirelessState)
+		_ = v.RegisterValidation("wirelessprofile", dto.ValidateWirelessProfile)
+	}
 }
 
 func domainsTest(t *testing.T) (*mocks.MockDomainsFeature, *gin.Engine) {

--- a/internal/controller/httpapi/v1/ieee8021xconfigs.go
+++ b/internal/controller/httpapi/v1/ieee8021xconfigs.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -20,17 +21,30 @@ type ieee8021xConfigRoutes struct {
 	l logger.Interface
 }
 
-func NewIEEE8021xConfigRoutes(handler *gin.RouterGroup, t ieee8021xconfigs.Feature, l logger.Interface) {
-	r := &ieee8021xConfigRoutes{t, l}
+var ieee8021xValidatorsOnce sync.Once
 
-	if binding.Validator != nil {
+// registerIEEE8021xValidators installs this route group's custom tags on the process-wide
+// validator engine. That engine's tag map is not safe for concurrent use, so
+// registration runs once and must finish before any request is served.
+func registerIEEE8021xValidators(l logger.Interface) {
+	ieee8021xValidatorsOnce.Do(func() {
+		if binding.Validator == nil {
+			return
+		}
+
 		if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 			err := v.RegisterValidation("authProtocolValidator", dto.AuthProtocolValidator)
 			if err != nil {
 				l.Error(err, "failed to register validation")
 			}
 		}
-	}
+	})
+}
+
+func NewIEEE8021xConfigRoutes(handler *gin.RouterGroup, t ieee8021xconfigs.Feature, l logger.Interface) {
+	r := &ieee8021xConfigRoutes{t, l}
+
+	registerIEEE8021xValidators(l)
 
 	h := handler.Group("/ieee8021xconfigs")
 	{

--- a/internal/controller/httpapi/v1/profiles.go
+++ b/internal/controller/httpapi/v1/profiles.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -21,10 +21,18 @@ type profileRoutes struct {
 	l logger.Interface
 }
 
-func NewProfileRoutes(handler *gin.RouterGroup, t profiles.Feature, l logger.Interface) {
-	r := &profileRoutes{t, l}
+var profileValidatorsOnce sync.Once
 
-	if binding.Validator != nil {
+// registerProfileValidators installs this route group's custom tags on the
+// process-wide validator engine. That engine's tag map is not safe for
+// concurrent use, so registration runs once and must finish before any request
+// is served — NewRouter calls this while wiring the routes.
+func registerProfileValidators() {
+	profileValidatorsOnce.Do(func() {
+		if binding.Validator == nil {
+			return
+		}
+
 		if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 			_ = v.RegisterValidation("genpasswordwone", dto.ValidateAMTPassOrGenRan)
 			_ = v.RegisterValidation("ciraortls", dto.ValidateCIRAOrTLS)
@@ -32,7 +40,13 @@ func NewProfileRoutes(handler *gin.RouterGroup, t profiles.Feature, l logger.Int
 			_ = v.RegisterValidation("profilename", dto.ValidateProfileName)
 			_ = v.RegisterValidation("amtpasswordcomplexity", dto.ValidateAMTPasswordComplexity)
 		}
-	}
+	})
+}
+
+func NewProfileRoutes(handler *gin.RouterGroup, t profiles.Feature, l logger.Interface) {
+	r := &profileRoutes{t, l}
+
+	registerProfileValidators()
 
 	h := handler.Group("/profiles")
 	{
@@ -146,8 +160,10 @@ func (r *profileRoutes) update(c *gin.Context) {
 	}
 
 	var profile dto.Profile
-	if err := json.Unmarshal(body, &profile); err != nil {
-		validationErr := ErrValidationProfile.Wrap("update", "json.Unmarshal", err)
+	// BindBody decodes and runs the struct validators. Plain json.Unmarshal
+	// would skip them, letting an invalid profile through on PATCH.
+	if err := binding.JSON.BindBody(body, &profile); err != nil {
+		validationErr := ErrValidationProfile.Wrap("update", "BindBody", err)
 		ErrorResponse(c, validationErr)
 
 		return

--- a/internal/controller/httpapi/v1/profiles_test.go
+++ b/internal/controller/httpapi/v1/profiles_test.go
@@ -443,9 +443,42 @@ func TestProfilesInsertWithoutPasswordFails(t *testing.T) {
 
 			profileFeature.EXPECT().
 				Insert(gomock.Any(), gomock.Any()).
-				Return(nil, profiles.ErrNotValid.Wrap("Insert", "validateProfileCreate", tc.wantErr))
+				Return(nil, profiles.ErrNotValid.Wrap("Insert", "validateProfilePasswords", tc.wantErr))
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/profiles", bytes.NewBuffer([]byte(tc.body)))
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// PATCH binds through the validator, so a body that violates the struct tags is
+// rejected before the feature is reached.
+func TestProfilesUpdatePatchRejectsInvalidBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"activation outside oneof", `{"profileName":"newprofile","activation":"activate"}`},
+		{"amtPassword fails complexity", `{"profileName":"newprofile","activation":"ccmactivate","amtPassword":"Intel123"}`},
+		{"profileName missing", `{"activation":"ccmactivate"}`},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// No mock expectations: reaching the feature would fail the test.
+			_, engine := profilesTest(t)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, "/api/v1/admin/profiles", bytes.NewBufferString(tc.body))
 			require.NoError(t, err)
 
 			w := httptest.NewRecorder()

--- a/internal/controller/httpapi/v1/wificonfigs.go
+++ b/internal/controller/httpapi/v1/wificonfigs.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -20,17 +21,30 @@ type WirelessConfigRoutes struct {
 	l logger.Interface
 }
 
-func NewWirelessConfigRoutes(handler *gin.RouterGroup, t wificonfigs.Feature, l logger.Interface) {
-	r := &WirelessConfigRoutes{t, l}
+var wirelessValidatorsOnce sync.Once
 
-	if binding.Validator != nil {
+// registerWirelessValidators installs this route group's custom tags on the process-wide
+// validator engine. That engine's tag map is not safe for concurrent use, so
+// registration runs once and must finish before any request is served.
+func registerWirelessValidators(l logger.Interface) {
+	wirelessValidatorsOnce.Do(func() {
+		if binding.Validator == nil {
+			return
+		}
+
 		if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 			err := v.RegisterValidation("authforieee8021x", dto.ValidateAuthandIEEE)
 			if err != nil {
 				l.Error(err, "failed to register validation")
 			}
 		}
-	}
+	})
+}
+
+func NewWirelessConfigRoutes(handler *gin.RouterGroup, t wificonfigs.Feature, l logger.Interface) {
+	r := &WirelessConfigRoutes{t, l}
+
+	registerWirelessValidators(l)
 
 	h := handler.Group("/wirelessconfigs")
 	{

--- a/internal/usecase/profiles/usecase.go
+++ b/internal/usecase/profiles/usecase.go
@@ -49,9 +49,11 @@ var (
 
 const CIRADisabledHint = "Re-enable CIRA on this instance, or change the connection mode on this profile."
 
-// validateProfileCreate enforces password-required invariants that only apply on
-// POST: PATCH may omit either password to leave the stored value untouched.
-func validateProfileCreate(d *dto.Profile) error {
+// validateProfilePasswords enforces the password-required invariants. On POST it
+// runs against the submitted profile; on PATCH it runs against the merged profile
+// (applyPATCHMerge fills in the stored passwords), so omitting a password still
+// leaves the stored value untouched but can no longer leave the profile without one.
+func validateProfilePasswords(d *dto.Profile) error {
 	if !d.GenerateRandomPassword && d.AMTPassword == "" {
 		return ErrAMTPasswordRequired
 	}
@@ -523,6 +525,13 @@ func (uc *UseCase) Update(ctx context.Context, d *dto.Profile, fields map[string
 		}
 
 		d = merged
+
+		// The merged profile is what gets stored, so the password invariants are
+		// checked against it: omitting a password still keeps the stored one, but
+		// a merge that leaves the profile without one is rejected.
+		if err := validateProfilePasswords(d); err != nil {
+			return nil, ErrNotValid.Wrap("Update", "validateProfilePasswords", err)
+		}
 	}
 
 	if err := uc.validateCIRAConfig(d.CIRAConfigName); err != nil {
@@ -568,8 +577,8 @@ func (uc *UseCase) Update(ctx context.Context, d *dto.Profile, fields map[string
 }
 
 func (uc *UseCase) Insert(ctx context.Context, d *dto.Profile) (*dto.Profile, error) {
-	if err := validateProfileCreate(d); err != nil {
-		return nil, ErrNotValid.Wrap("Insert", "validateProfileCreate", err)
+	if err := validateProfilePasswords(d); err != nil {
+		return nil, ErrNotValid.Wrap("Insert", "validateProfilePasswords", err)
 	}
 
 	if err := uc.validateCIRAConfig(d.CIRAConfigName); err != nil {

--- a/internal/usecase/profiles/usecase_test.go
+++ b/internal/usecase/profiles/usecase_test.go
@@ -1452,3 +1452,87 @@ func TestUpdateAllowsNonCIRAProfileWhenCIRADisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, profileDTO, result)
 }
+
+// A PATCH that clears a password is validated against the merged profile: the
+// stored value is gone, so the profile would be left without one.
+func TestUpdateRejectsMergedProfileWithoutPasswords(t *testing.T) {
+	t.Parallel()
+
+	tenantID := "tenant-id-456"
+
+	tests := []struct {
+		name    string
+		stored  *entity.Profile
+		payload *dto.Profile
+		fields  map[string]bool
+		wantErr error
+	}{
+		{
+			name: "amtPassword cleared while generateRandomPassword is false",
+			stored: &entity.Profile{
+				ProfileName: "example-profile",
+				TenantID:    tenantID,
+				Activation:  "ccmactivate",
+			},
+			payload: &dto.Profile{
+				ProfileName:            "example-profile",
+				TenantID:               tenantID,
+				Activation:             "ccmactivate",
+				AMTPassword:            "",
+				GenerateRandomPassword: false,
+			},
+			fields: map[string]bool{
+				"profilename":            true,
+				"activation":             true,
+				"amtpassword":            true,
+				"generaterandompassword": true,
+			},
+			wantErr: profiles.ErrAMTPasswordRequired,
+		},
+		{
+			name: "mebxPassword cleared while switching to acmactivate",
+			stored: &entity.Profile{
+				ProfileName: "example-profile",
+				TenantID:    tenantID,
+				Activation:  "ccmactivate",
+			},
+			payload: &dto.Profile{
+				ProfileName:                "example-profile",
+				TenantID:                   tenantID,
+				Activation:                 "acmactivate",
+				MEBXPassword:               "",
+				GenerateRandomMEBxPassword: false,
+			},
+			fields: map[string]bool{
+				"profilename":                true,
+				"activation":                 true,
+				"mebxpassword":               true,
+				"generaterandommebxpassword": true,
+			},
+			wantErr: profiles.ErrMEBXPasswordRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			useCase, repo, _, profilewifi := profilesTest(t)
+
+			repo.EXPECT().
+				GetByName(context.Background(), tc.stored.ProfileName, tenantID).
+				Return(tc.stored, nil)
+			profilewifi.EXPECT().
+				GetByProfileName(context.Background(), tc.stored.ProfileName, tenantID).
+				Return(nil, nil)
+
+			// No repo.Update expectation: the merge must be rejected before the write.
+			_, err := useCase.Update(context.Background(), tc.payload, tc.fields)
+
+			require.Error(t, err)
+			require.IsType(t, dto.NotValidError{}, err)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## What

`PATCH /api/v1/devices` and `PATCH /api/v1/admin/profiles` decoded the request body with `json.Unmarshal`, which runs no validators. Both handlers used `ShouldBindBodyWithJSON` until #1169 replaced it while adding the partial-update field map, so every `binding` tag on `dto.Device` and `dto.Profile` has been unenforced on PATCH since August.

Reproduced against a running instance:

```
POST /api/v1/admin/profiles  {"profileName":"p","amtPassword":"P@ssw0rd",
                              "activation":"ccmactivate", ...}          201
PATCH /api/v1/admin/profiles {"profileName":"p","activation":"acmactivate",
                              "generateRandomMEBxPassword":false}       200  <-- stored
GET  /api/v1/admin/profiles/p            activation: acmactivate, no MEBX password
```

ACM activation requires a MEBX password, so that profile cannot activate a device. The same path accepted `"activation":"activate"`, outside the `oneof` list.

## How

- Bind through `binding.JSON.BindBody`, which decodes **and** validates.
- Run the password invariants against the **merged** profile instead of only on insert. Omitting a password in a PATCH still keeps the stored one — `applyPATCHMerge` fills it in — but a merge that would leave the profile with no password is rejected.

Two supporting changes:

- The v1 handler tests called `gin.DisableBindValidation()` from a package `init()`, which nils `binding.Validator` for the entire test binary. **No handler test has ever exercised validation**, which is how the regression shipped unnoticed. The tests now register the same validators `NewRouter` installs.
- Registering custom tags from a route constructor races a request being validated on another goroutine — the validator engine's tag map is not safe for concurrent use. The race detector reports this on `main` today. Registration is now guarded by `sync.Once` and pre-run from the test `init()`, before any parallel test serves a request.

`addCertificate - missing required field` asserted 500 because validation was off; it now asserts the 400 its name implies.

## Compatibility

This **tightens** `/api/v1`: a PATCH body violating a binding tag returns 400 where it recently returned 200, and `profileName` / `activation` are required on a profile PATCH again. That restores the pre-#1169 contract rather than adding a new restriction, and `sample-web-ui` already sends the full object on update (`profiles.service.ts:48`).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -s -l` — clean
- `go test -count=1 ./...` — pass
- `go test -race -count=1 ./...` — pass, no data races (run on Linux; `-race` needs cgo)
- New: `TestProfilesUpdatePatchRejectsInvalidBody` (3 cases), `TestDevicesUpdatePatchRejectsInvalidBody`, `TestUpdateRejectsMergedProfileWithoutPasswords` (2 cases)

Found while re-enabling the RPS Postman collection, which has not run in CI since #217 — 13 of its assertions fail on this bug. The CI change that turns the collection back on follows in a separate PR and depends on this one.

No route, request shape, or OpenAPI declaration changes, so `internal/controller/openapi/` and the Postman collections are untouched here.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCV2vuSwoz7J5VV2hZxcWe
