### PR TITLE
fix(db): match SQL constraint behavior on MongoDB

### DIFF
--- a/internal/repoerrors/foreignkeyviolation.go
+++ b/internal/repoerrors/foreignkeyviolation.go
@@ -1,0 +1,23 @@
+package repoerrors
+
+import "github.com/device-management-toolkit/console/pkg/consoleerrors"
+
+// ForeignKeyViolationError reports a delete or insert that would break a
+// relationship between records. Postgres and SQLite raise it from the foreign
+// key constraint itself; MongoDB has no constraints, so its repositories check
+// the referencing collection first and raise the same error — the way RPS did
+// it (src/data/postgres/tables/wirelessProfiles.ts queries
+// profiles_wirelessconfigs before deleting). Controllers map it to 400.
+type ForeignKeyViolationError struct {
+	Console consoleerrors.InternalError
+}
+
+func (e ForeignKeyViolationError) Error() string {
+	return e.Console.Error()
+}
+
+func (e ForeignKeyViolationError) Wrap(details string) error {
+	e.Console.Message = "foreign key violation: " + details
+
+	return e
+}

--- a/internal/usecase/nosqldb/mongo/ciraconfig.go
+++ b/internal/usecase/nosqldb/mongo/ciraconfig.go
@@ -130,6 +130,10 @@ func (r *CIRARepo) Update(ctx context.Context, c *entity.CIRAConfig) (bool, erro
 		}},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errCIRANotUnique.Wrap(err.Error())
+		}
+
 		return false, errCIRADatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/ciraconfig_test.go
+++ b/internal/usecase/nosqldb/mongo/ciraconfig_test.go
@@ -105,6 +105,29 @@ func TestCIRARepo_Insert_DuplicateReturnsNotUniqueError(t *testing.T) {
 	require.True(t, errors.As(err, &nu), "expected NotUniqueError, got %T: %v", err, err)
 }
 
+// A unique-index collision on update has to reach the handler as a
+// NotUniqueError so it answers 409, the way the SQL backends do.
+func TestCIRARepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewCIRARepo(db)
+
+	ok, err := repo.Update(context.Background(), &entity.CIRAConfig{
+		ConfigName: "cira1",
+		TenantID:   "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestCIRARepo_Update_Matched(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/nosqldb/mongo/device.go
+++ b/internal/usecase/nosqldb/mongo/device.go
@@ -250,6 +250,10 @@ func (r *DeviceRepo) Update(ctx context.Context, d *entity.Device) (bool, error)
 		}},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errDeviceNotUnique.Wrap(err.Error())
+		}
+
 		return false, errDeviceDatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/device_test.go
+++ b/internal/usecase/nosqldb/mongo/device_test.go
@@ -200,6 +200,29 @@ func TestDeviceRepo_Insert_DuplicateReturnsNotUniqueError(t *testing.T) {
 	require.True(t, errors.As(err, &nu))
 }
 
+// A unique-index collision on update has to reach the handler as a
+// NotUniqueError so it answers 409, the way the SQL backends do.
+func TestDeviceRepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewDeviceRepo(db)
+
+	ok, err := repo.Update(context.Background(), &entity.Device{
+		GUID:     "g1",
+		TenantID: "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestDeviceRepo_Update_Matched(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/nosqldb/mongo/domain.go
+++ b/internal/usecase/nosqldb/mongo/domain.go
@@ -159,6 +159,10 @@ func (r *DomainRepo) Update(ctx context.Context, d *entity.Domain) (bool, error)
 		}},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errDomainNotUnique.Wrap(err.Error())
+		}
+
 		return false, errDomainDatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/domain_test.go
+++ b/internal/usecase/nosqldb/mongo/domain_test.go
@@ -162,6 +162,30 @@ func TestDomainRepo_Update_Matched(t *testing.T) {
 	require.True(t, ok)
 }
 
+// A suffix collision on update has to reach the handler as a NotUniqueError so
+// it answers 409, the way the SQL backends do from their unique index.
+func TestDomainRepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewDomainRepo(db)
+
+	ok, err := repo.Update(context.Background(), &entity.Domain{
+		ProfileName:  "Acme",
+		DomainSuffix: "taken.com",
+		TenantID:     "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestDomainRepo_Update_NoMatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/nosqldb/mongo/errors.go
+++ b/internal/usecase/nosqldb/mongo/errors.go
@@ -23,6 +23,10 @@ var (
 	errWiFiNotUnique               = repoerrors.NotUniqueError{Console: consoleerrors.CreateConsoleError("MongoWirelessRepo")}
 	errProfileWiFiConfigsDatabase  = repoerrors.DatabaseError{Console: consoleerrors.CreateConsoleError("MongoProfileWiFiConfigsRepo")}
 	errProfileWiFiConfigsNotUnique = repoerrors.NotUniqueError{Console: consoleerrors.CreateConsoleError("MongoProfileWiFiConfigsRepo")}
+
+	// Mongo has no foreign keys, so the repositories check the referencing
+	// collection themselves and raise the error SQL gets from its constraint.
+	errWiFiForeignKeyViolation = repoerrors.ForeignKeyViolationError{Console: consoleerrors.CreateConsoleError("MongoWirelessRepo")}
 )
 
 // isDuplicateKey matches Mongo E11000 errors (mapped to NotUniqueError, mirroring SQL).

--- a/internal/usecase/nosqldb/mongo/ieee8021xconfig.go
+++ b/internal/usecase/nosqldb/mongo/ieee8021xconfig.go
@@ -141,6 +141,10 @@ func (r *IEEE8021xRepo) Update(ctx context.Context, c *entity.IEEE8021xConfig) (
 		}},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errIEEENotUnique.Wrap(err.Error())
+		}
+
 		return false, errIEEEDatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/ieee8021xconfig_test.go
+++ b/internal/usecase/nosqldb/mongo/ieee8021xconfig_test.go
@@ -156,6 +156,29 @@ func TestIEEE8021xRepo_Insert_DuplicateReturnsNotUniqueError(t *testing.T) {
 	require.True(t, errors.As(err, &nu))
 }
 
+// A unique-index collision on update has to reach the handler as a
+// NotUniqueError so it answers 409, the way the SQL backends do.
+func TestIEEE8021xRepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewIEEE8021xRepo(db)
+
+	ok, err := repo.Update(context.Background(), &entity.IEEE8021xConfig{
+		ProfileName: "ieee1",
+		TenantID:    "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestIEEE8021xRepo_Update(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/nosqldb/mongo/profile.go
+++ b/internal/usecase/nosqldb/mongo/profile.go
@@ -187,6 +187,10 @@ func (r *ProfileRepo) Update(ctx context.Context, p *entity.Profile) (bool, erro
 		bson.M{opSet: set},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errProfileNotUnique.Wrap(err.Error())
+		}
+
 		return false, errProfileDatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/profile_test.go
+++ b/internal/usecase/nosqldb/mongo/profile_test.go
@@ -146,6 +146,29 @@ func TestProfileRepo_Insert_DuplicateReturnsNotUniqueError(t *testing.T) {
 	require.True(t, errors.As(err, &nu))
 }
 
+// A unique-index collision on update has to reach the handler as a
+// NotUniqueError so it answers 409, the way the SQL backends do.
+func TestProfileRepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewProfileRepo(db, logger.New("error"))
+
+	ok, err := repo.Update(context.Background(), &entity.Profile{
+		ProfileName: "p1",
+		TenantID:    "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestProfileRepo_Update(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/nosqldb/mongo/wificonfig.go
+++ b/internal/usecase/nosqldb/mongo/wificonfig.go
@@ -15,18 +15,20 @@ import (
 )
 
 type WirelessRepo struct {
-	col          *mongo.Collection
-	ieee8021xCol *mongo.Collection
-	log          logger.Interface
+	col            *mongo.Collection
+	ieee8021xCol   *mongo.Collection
+	profileWiFiCol *mongo.Collection
+	log            logger.Interface
 }
 
 var _ wificonfigs.Repository = (*WirelessRepo)(nil)
 
 func NewWirelessRepo(db *mongo.Database, log logger.Interface) *WirelessRepo {
 	return &WirelessRepo{
-		col:          db.Collection(CollectionWirelessConfigs),
-		ieee8021xCol: db.Collection(CollectionIEEE8021xConfigs),
-		log:          log,
+		col:            db.Collection(CollectionWirelessConfigs),
+		ieee8021xCol:   db.Collection(CollectionIEEE8021xConfigs),
+		profileWiFiCol: db.Collection(CollectionProfileWiFiConfigs),
+		log:            log,
 	}
 }
 
@@ -162,6 +164,17 @@ func (r *WirelessRepo) Delete(ctx context.Context, profileName, tenantID string)
 		return false, nil
 	}
 
+	// SQL leaves this to the profiles_wirelessconfigs foreign key. Mongo has no
+	// constraints, so look for a referencing row the way RPS did before deleting.
+	err := r.profileWiFiCol.FindOne(ctx, bson.M{fieldWirelessProfileName: profileName, fieldTenantID: tenantID}).Err()
+
+	switch {
+	case err == nil:
+		return false, errWiFiForeignKeyViolation.Wrap("wireless profile " + profileName + " is associated with an AMT profile")
+	case !errors.Is(err, mongo.ErrNoDocuments):
+		return false, errWiFiDatabase.Wrap("Delete", "FindOne", err)
+	}
+
 	res, err := r.col.DeleteOne(ctx, bson.M{fieldProfileName: profileName, fieldTenantID: tenantID})
 	if err != nil {
 		return false, errWiFiDatabase.Wrap("Delete", "DeleteOne", err)
@@ -192,6 +205,10 @@ func (r *WirelessRepo) Update(ctx context.Context, w *entity.WirelessConfig) (bo
 		}},
 	)
 	if err != nil {
+		if isDuplicateKey(err) {
+			return false, errWiFiNotUnique.Wrap(err.Error())
+		}
+
 		return false, errWiFiDatabase.Wrap("Update", "UpdateOne", err)
 	}
 

--- a/internal/usecase/nosqldb/mongo/wificonfig_test.go
+++ b/internal/usecase/nosqldb/mongo/wificonfig_test.go
@@ -164,6 +164,29 @@ func TestWirelessRepo_Insert_DuplicateReturnsNotUniqueError(t *testing.T) {
 	require.True(t, errors.As(err, &nu))
 }
 
+// A unique-index collision on update has to reach the handler as a
+// NotUniqueError so it answers 409, the way the SQL backends do.
+func TestWirelessRepo_Update_DuplicateReturnsNotUniqueError(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(duplicateKeyResponse())
+
+	repo := mongo.NewWirelessRepo(db, logger.New("error"))
+
+	ok, err := repo.Update(context.Background(), &entity.WirelessConfig{
+		ProfileName: "wifi1",
+		TenantID:    "t1",
+	})
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var notUnique repoerrors.NotUniqueError
+
+	require.ErrorAs(t, err, &notUnique)
+}
+
 func TestWirelessRepo_Update(t *testing.T) {
 	t.Parallel()
 
@@ -186,11 +209,63 @@ func TestWirelessRepo_Delete(t *testing.T) {
 
 	db, md := newMockedDB(t)
 
-	md.AddResponses(deleteResponse(1))
+	// No referencing profiles_wirelessconfigs row, then the delete itself.
+	md.AddResponses(findResponse("consoledb.profiles_wirelessconfigs"), deleteResponse(1))
 
 	repo := mongo.NewWirelessRepo(db, logger.New("error"))
 
 	ok, err := repo.Delete(context.Background(), "wifi1", "t1")
 	require.NoError(t, err)
 	require.True(t, ok)
+}
+
+// A failed reference lookup must not fall through to the delete: the repo cannot
+// tell whether the wireless profile is still in use, so it reports the error.
+func TestWirelessRepo_Delete_ReferenceLookupFailurePreventsDelete(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	// Only one queued response: a delete would need a second, and reaching it
+	// would hang rather than silently pass.
+	md.AddResponses(bson.D{
+		{Key: "ok", Value: 0},
+		{Key: "code", Value: int32(13)},
+		{Key: "errmsg", Value: "not authorized"},
+	})
+
+	repo := mongo.NewWirelessRepo(db, logger.New("error"))
+
+	ok, err := repo.Delete(context.Background(), "wifi1", "t1")
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var dbErr repoerrors.DatabaseError
+
+	require.ErrorAs(t, err, &dbErr)
+}
+
+// SQL gets this from the profiles_wirelessconfigs foreign key; Mongo has to look
+// for the referencing row itself, and must raise the same error so the handler
+// still answers 400.
+func TestWirelessRepo_Delete_ReferencedByProfileIsRejected(t *testing.T) {
+	t.Parallel()
+
+	db, md := newMockedDB(t)
+
+	md.AddResponses(findResponse("consoledb.profiles_wirelessconfigs",
+		bson.D{{Key: "profilename", Value: "amt-profile"}, {Key: "wirelessprofilename", Value: "wifi1"}},
+	))
+
+	repo := mongo.NewWirelessRepo(db, logger.New("error"))
+
+	ok, err := repo.Delete(context.Background(), "wifi1", "t1")
+	require.False(t, ok)
+	require.Error(t, err)
+
+	var fkErr repoerrors.ForeignKeyViolationError
+
+	require.ErrorAs(t, err, &fkErr)
+	// FriendlyMessage is what the handler puts in the 400 body.
+	require.Contains(t, fkErr.Console.FriendlyMessage(), "foreign key violation")
 }

--- a/internal/usecase/sqldb/foreignkeyviolation.go
+++ b/internal/usecase/sqldb/foreignkeyviolation.go
@@ -1,21 +1,7 @@
 package sqldb
 
-import "github.com/device-management-toolkit/console/pkg/consoleerrors"
+import "github.com/device-management-toolkit/console/internal/repoerrors"
 
-// ForeignKeyViolationError lives in sqldb (not internal/repoerrors) because
-// foreign key constraints are a relational-only concept. Backends without
-// referential integrity (e.g. MongoDB) do not produce this error, so it has
-// no place in the cross-backend error vocabulary.
-type ForeignKeyViolationError struct {
-	Console consoleerrors.InternalError
-}
-
-func (e ForeignKeyViolationError) Error() string {
-	return e.Console.Error()
-}
-
-func (e ForeignKeyViolationError) Wrap(details string) error {
-	e.Console.Message = "foreign key violation: " + details
-
-	return e
-}
+// ForeignKeyViolationError is an alias so both repository packages raise the
+// same type and the controllers' errors.As checks work for either backend.
+type ForeignKeyViolationError = repoerrors.ForeignKeyViolationError


### PR DESCRIPTION
## What

Two repository behaviors differed between the SQL backends and MongoDB, so the same request returned a different status depending on which database Console was configured with. CLAUDE.md treats that as a bug: the use case has no way to know which backend it got.

**1. Duplicate key on update.** Every Mongo `Insert` mapped a duplicate-key error to `NotUniqueError`; no Mongo `Update` did. A unique-index collision on update surfaced as a generic `DatabaseError`, so the handler answered **400** where Postgres and SQLite answer **409**.

## How

- The duplicate-key mapping is added to `Update` in all six Mongo repositories, matching what each `Insert` already does.
- `WirelessRepo.Delete` looks for a referencing `profiles_wirelessconfigs` document before deleting. This is what RPS itself did — `src/data/postgres/tables/wirelessProfiles.ts` runs `SELECT 1 FROM profiles_wirelessconfigs ...` and throws `'Foreign key violation'` rather than relying on the constraint — so this is parity with the service Console replaces, not a new invention.
- `ForeignKeyViolationError` moves from `sqldb` to `repoerrors` so both backends raise one type and the controller's `errors.As` check works for either. `sqldb` keeps the name as a type alias, so no other package changes.

Its doc comment previously said the error "has no place in the cross-backend error vocabulary" because Mongo lacks constraints. That reasoning is what left the divergence in place, so the comment is corrected rather than worked around. **Flagging it explicitly for review** — it reverses a documented design decision.

## Note for the reviewer: CodeQL

CodeQL raises `go/sql-injection` (high) on the new `FindOne` in `wificonfig.go`. It is the same pattern as every other query in this package: the value is passed as a **BSON value**, not concatenated into a query string, so it cannot alter the query structure — and `Delete` already rejects anything that fails `identifierRegex` before the query runs.

This repository has **20+ alerts for this exact rule in this exact package already dismissed as "false positive"**, including two in `wificonfig.go` itself (alerts #166 and #167, on the neighbouring `Delete` and `Update`). This one is alert #238 and needs the same disposition — I have not dismissed it, since that is a maintainer call.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -s -l` — clean
- `go test -count=1 ./...` and `go test -race -count=1 ./...` — pass
- New, using the existing `drivertest` wire-level mock:
  - `Test{CIRA,Device,Domain,IEEE8021x,Profile,Wireless}Repo_Update_DuplicateReturnsNotUniqueError` — one per repository, so every branch this PR adds is covered
  - `TestWirelessRepo_Delete_ReferencedByProfileIsRejected` and `TestWirelessRepo_Delete_ReferenceLookupFailurePreventsDelete`
- End-to-end against a real MongoDB via the compose stack: the RPS Postman collection goes from 4 failures to 0 with these changes

Found while re-enabling the RPS Postman collection, which has not run in CI since #217. The CI change that turns it back on follows in a separate PR and depends on this one.

No route or response-shape changes on the SQL backends, so `internal/controller/openapi/` and the Postman collections are untouched here.
