### PR TITLE
fix(config): generate auth.jwtKey on first run instead of failing to start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,9 +58,10 @@ EA_PASSWORD=
 # Auth
 AUTH_DISABLED=false
 AUTH_ADMIN_USERNAME=standalone
-# AUTH_ADMIN_PASSWORD: uncomment this line to set your own password; otherwise Console generates one in config.yml
-# Required when AUTH_DISABLED=false. Set a strong, unique signing secret.
-AUTH_JWT_KEY=
+# Uncomment to set your own admin password; otherwise Console generates one in config.yml
+# AUTH_ADMIN_PASSWORD=
+# Uncomment to set your own JWT signing secret; otherwise Console generates one in config.yml
+# AUTH_JWT_KEY=
 AUTH_JWT_EXPIRATION=24h
 AUTH_REDIRECTION_JWT_EXPIRATION=5m
 # Ignored when AUTH_CLIENT_ID is set (OIDC).

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/ilyakaznacheev/cleanenv"
 	"gopkg.in/yaml.v2"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/security"
 )
 
 var ConsoleConfig *Config
@@ -121,7 +124,7 @@ type (
 		Disabled                 bool          `yaml:"disabled" env:"AUTH_DISABLED"`
 		AdminUsername            string        `yaml:"adminUsername" env:"AUTH_ADMIN_USERNAME"`
 		AdminPassword            string        `yaml:"adminPassword" env:"AUTH_ADMIN_PASSWORD"`
-		JWTKey                   string        `env-required:"true" yaml:"jwtKey" env:"AUTH_JWT_KEY"`
+		JWTKey                   string        `yaml:"jwtKey" env:"AUTH_JWT_KEY"`
 		JWTExpiration            time.Duration `yaml:"jwtExpiration" env:"AUTH_JWT_EXPIRATION"`
 		RedirectionJWTExpiration time.Duration `yaml:"redirectionJWTExpiration" env:"AUTH_REDIRECTION_JWT_EXPIRATION"`
 		ClientID                 string        `yaml:"clientId" env:"AUTH_CLIENT_ID"`
@@ -392,6 +395,11 @@ func SaveAdminPassword(adminPassword string) error {
 		return err
 	}
 
+	return updateConfigFile(configPath, func(c *Config) { c.AdminPassword = adminPassword })
+}
+
+// updateConfigFile applies mutate to the file's own contents, never to the env-overlaid Config.
+func updateConfigFile(configPath string, mutate func(*Config)) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return err
@@ -402,9 +410,53 @@ func SaveAdminPassword(adminPassword string) error {
 		return err
 	}
 
-	fileCfg.AdminPassword = adminPassword
+	mutate(fileCfg)
 
 	return writeConfig(configPath, fileCfg)
+}
+
+// ensureJWTKey mirrors the admin-password flow: a key from config or env is
+// used as-is, disabled auth needs none, and otherwise a random key is generated
+// and persisted so every restart signs tokens with the same secret.
+func ensureJWTKey(configPath string, cfg *Config) error {
+	if cfg.Disabled || cfg.JWTKey != "" {
+		return nil
+	}
+
+	key := security.Crypto{}.GenerateKey()
+
+	if err := updateConfigFile(configPath, func(c *Config) { c.JWTKey = key }); err != nil {
+		return fmt.Errorf("config: persisting generated auth.jwtKey to %s (set AUTH_JWT_KEY to provide one instead): %w", configPath, err)
+	}
+
+	cfg.JWTKey = key
+
+	log.Printf(
+		"WARNING: no auth.jwtKey was configured, so a random one was generated and saved to %s. "+
+			"Local basic auth is meant for single-user deployments; for production, configure your own "+
+			"OAuth2/OIDC provider via auth.clientId and auth.issuer instead.",
+		configPath,
+	)
+
+	return nil
+}
+
+// loadConfig layers the file (created with defaults on first run) and the
+// environment onto cfg, then generates auth.jwtKey when nothing supplied one.
+func loadConfig(configPath string, cfg *Config) error {
+	if err := readOrInitConfig(configPath, cfg); err != nil {
+		return err
+	}
+
+	if err := cleanenv.ReadEnv(cfg); err != nil {
+		return err
+	}
+
+	if err := ensureJWTKey(configPath, cfg); err != nil {
+		return err
+	}
+
+	return cfg.validate()
 }
 
 // validate checks that all Config values are sane.
@@ -461,19 +513,7 @@ func NewConfig() (*Config, error) {
 		}
 	}
 
-	if err := readOrInitConfig(configPath, ConsoleConfig); err != nil {
-		ConsoleConfig = nil
-
-		return nil, err
-	}
-
-	if err := cleanenv.ReadEnv(ConsoleConfig); err != nil {
-		ConsoleConfig = nil
-
-		return nil, err
-	}
-
-	if err := ConsoleConfig.validate(); err != nil {
+	if err := loadConfig(configPath, ConsoleConfig); err != nil {
 		ConsoleConfig = nil
 
 		return nil, err

--- a/config/config.yml
+++ b/config/config.yml
@@ -39,7 +39,6 @@ auth:
   disabled: false
   adminUsername: standalone
   adminPassword: 
-  # Required when auth is enabled. Set a strong, unique signing secret.
   jwtKey: ""
   jwtExpiration: 24h0m0s
   redirectionJWTExpiration: 5m0s

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,14 +1,18 @@
 package config
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/ilyakaznacheev/cleanenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func clearEnv() {
@@ -521,4 +525,87 @@ func TestValidate_ValidDefaults(t *testing.T) {
 
 	err := cfg.validate()
 	require.NoError(t, err)
+}
+
+// readConfigFile parses what is on disk, bypassing the env overlay.
+func readConfigFile(t *testing.T, path string) *Config {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	fileCfg := defaultConfig()
+	require.NoError(t, yaml.Unmarshal(data, fileCfg))
+
+	return fileCfg
+}
+
+func TestEnsureJWTKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		disabled      bool
+		key           string
+		wantGenerated bool
+	}{
+		{"generates and persists when auth is enabled and no key is set", false, "", true},
+		{"keeps a configured key and never writes it to disk", false, "from-env", false},
+		{"skips generation when auth is disabled", true, "", false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "config.yml")
+			require.NoError(t, writeConfig(path, defaultConfig()))
+
+			cfg := defaultConfig()
+			cfg.Disabled = tc.disabled
+			cfg.JWTKey = tc.key
+
+			require.NoError(t, ensureJWTKey(path, cfg))
+
+			if !tc.wantGenerated {
+				assert.Equal(t, tc.key, cfg.JWTKey)
+				assert.Empty(t, readConfigFile(t, path).JWTKey)
+
+				return
+			}
+
+			assert.Len(t, cfg.JWTKey, 44, "32 random bytes as base64, same as the encryption key")
+			assert.Equal(t, cfg.JWTKey, readConfigFile(t, path).JWTKey)
+
+			// A restart must reuse the persisted key rather than rotate it.
+			again := readConfigFile(t, path)
+			require.NoError(t, ensureJWTKey(path, again))
+			assert.Equal(t, cfg.JWTKey, again.JWTKey)
+		})
+	}
+}
+
+func TestEnsureJWTKey_WarnsAboutProductionUse(t *testing.T) { //nolint:paralleltest // rebinds the global log output
+	var buf bytes.Buffer
+
+	orig := log.Writer()
+
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(orig) })
+
+	path := filepath.Join(t.TempDir(), "config.yml")
+	require.NoError(t, writeConfig(path, defaultConfig()))
+
+	require.NoError(t, ensureJWTKey(path, defaultConfig()))
+	assert.Contains(t, buf.String(), "OAuth2")
+}
+
+// TestReadEnv_EmptyJWTKeyIsNotRejected guards against re-adding env-required to
+// JWTKey: that check runs before ensureJWTKey and ignores auth.disabled.
+func TestReadEnv_EmptyJWTKeyIsNotRejected(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, cleanenv.ReadEnv(defaultConfig()))
 }


### PR DESCRIPTION
After #1223 removed the hardcoded default, a fresh install with no AUTH_JWT_KEY refused to start. On Windows the fatal error is never visible because a double-clicked binary has no console, so the app just opens and closes.

Two checks rejected the empty key: the env-required tag on JWTKey (which fires inside cleanenv before validate() and also ignores auth.disabled) and validate() itself. Drop the tag and, mirroring the admin-password flow, generate a random key and persist it to config.yml when neither config nor env provides one and auth is enabled. A configured key is never overwritten, env-only keys are never written to disk, and a warning recommends OAuth2/OIDC for production. validate() keeps rejecting an empty key as a backstop.

Fixes: #1262